### PR TITLE
(GH-252) Update README for Org Move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 
-[![Version](https://vsmarketplacebadge.apphb.com/version-short/jpogran.puppet-vscode.svg)](https://marketplace.visualstudio.com/items?itemName=jpogran.puppet-vscode) [![Installs](https://vsmarketplacebadge.apphb.com/installs/jpogran.puppet-vscode.svg)](https://marketplace.visualstudio.com/items?itemName=jpogran.puppet-vscode) [![Build status](https://ci.appveyor.com/api/projects/status/kwt06e0lgs70us4c/branch/master?svg=true)](https://ci.appveyor.com/project/jpogran/puppet-vscode) [![Build Status](https://travis-ci.org/jpogran/puppet-vscode.svg?branch=master)](https://travis-ci.org/jpogran/puppet-vscode)
-
-
-# **FYI**: The Puppet VS Code extension is moving from https://github.com/jpogran/puppet-vscode to the https://github.com/lingua-pupuli  organization after the 0.10.0 release. All issues and commits will move over automatically, so there should be no appreciable difference for anyone. During the move the links below will not work. After the move we will issue a new release and the links will work in the Extension viewer.
+[![Version](https://vsmarketplacebadge.apphb.com/version-short/jpogran.puppet-vscode.svg)](https://marketplace.visualstudio.com/items?itemName=jpogran.puppet-vscode) [![Installs](https://vsmarketplacebadge.apphb.com/installs/jpogran.puppet-vscode.svg)](https://marketplace.visualstudio.com/items?itemName=jpogran.puppet-vscode) [![Build status](https://ci.appveyor.com/api/projects/status/kwt06e0lgs70us4c/branch/master?svg=true)](https://ci.appveyor.com/project/lingua-pupuli/puppet-vscode) [![Build Status](https://travis-ci.org/lingua-pupuli/puppet-vscode.svg?branch=master)](https://travis-ci.org/lingua-pupuli/puppet-vscode)
 
 # Puppet Language Support for Visual Studio Code
 
@@ -22,7 +19,7 @@ You will need to have Puppet Agent installed in order to fully use this extensio
 
 Create or open any Puppet manifest with the extension `.pp` or `.epp` and the extension will load automatically. Once loaded the extension will be available for the duration of the session.
 
-![Example of features](https://raw.githubusercontent.com/jpogran/puppet-vscode/master/client/docs/assets/language_server.gif)
+![Example of features](https://raw.githubusercontent.com/lingua-pupuli/puppet-vscode/master/docs/assets/language_server.gif)
 
 ## Platform support
 
@@ -132,7 +129,7 @@ Settings:
 
 `args` - Additional arguements to pass to `puppet apply`, for example `['--debug']` will output debug information
 
-![Puppet Debug Adapter](https://raw.githubusercontent.com/jpogran/puppet-vscode/master/client/docs/assets/puppet_debug.gif)
+![Puppet Debug Adapter](https://raw.githubusercontent.com/lingua-pupuli/puppet-vscode/master/docs/assets/puppet_debug.gif)
 
 ## Installing the Extension
 
@@ -147,14 +144,14 @@ If you haven't see the Problems Pane update in awhile, or hover and intellisense
 
 You can reload the Puppet Lanuguage Server by opening the command palette and starting to type `Puppet`. A list of Puppet commands will appear, select `Puppet: Restart Current Session`. This will restart the Puppet Language Server without reloading VSCode or losing any work currently open in the editor.
 
-![Reload Puppet Language Server](https://raw.githubusercontent.com/jpogran/puppet-vscode/master/client/docs/assets/reload_language_server.gif)
+![Reload Puppet Language Server](https://raw.githubusercontent.com/lingua-pupuli/puppet-vscode/master/docs/assets/reload_language_server.gif)
 
 ## Reporting Problems
 
 If you're having trouble with the Puppet extension, please follow these instructions
 to file an issue on our GitHub repository:
 
-### 1. File an issue on our [Issues Page](https://github.com/jpogran/puppet-vscode/issues)
+### 1. File an issue on our [Issues Page](https://github.com/lingua-pupuli/puppet-vscode/issues)
 
 Make sure to fill in the information that is requested in the issue template as it
 will help us investigate the problem more quickly.


### PR DESCRIPTION
This commit updated all references from `jpogran/puppet-vscode` to `lingua-pupuli` as well as removing any references to the `client` folder which was removed in GH-250

PR #251 must be merged first