### PR TITLE
(maint) Fix tslint errors in VS Code commands

### DIFF
--- a/src/commands/pdk/pdkNewClassCommand.ts
+++ b/src/commands/pdk/pdkNewClassCommand.ts
@@ -1,15 +1,13 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as cp from 'child_process';
-import ChildProcess = cp.ChildProcess;
 import { ILogger } from '../../logging';
 import { reporter } from '../../telemetry/telemetry';
 import * as messages from '../../messages';
 
-export class pdkNewClassCommand {
-  private logger: ILogger = undefined;
-  private terminal: vscode.Terminal = undefined;
+export class PDKNewClassCommand {
+  private logger: ILogger;
+  private terminal: vscode.Terminal;
 
   constructor(logger: ILogger, terminal: vscode.Terminal) {
     this.logger = logger;
@@ -33,6 +31,5 @@ export class pdkNewClassCommand {
 
   public dispose(): any {
     this.terminal.dispose();
-    this.terminal = undefined;
   }
 }

--- a/src/commands/pdk/pdkNewModuleCommand.ts
+++ b/src/commands/pdk/pdkNewModuleCommand.ts
@@ -5,9 +5,9 @@ import { ILogger } from '../../logging';
 import { reporter } from '../../telemetry/telemetry';
 import * as messages from '../../messages';
 
-export class pdkNewModuleCommand {
-  private logger: ILogger = undefined;
-  private terminal: vscode.Terminal = undefined;
+export class PDKNewModuleCommand {
+  private logger: ILogger;
+  private terminal: vscode.Terminal;
 
   constructor(logger: ILogger, terminal: vscode.Terminal) {
     this.logger = logger;
@@ -44,6 +44,5 @@ export class pdkNewModuleCommand {
 
   public dispose(): any {
     this.terminal.dispose();
-    this.terminal = undefined;
   }
 }

--- a/src/commands/pdk/pdkNewTaskCommand.ts
+++ b/src/commands/pdk/pdkNewTaskCommand.ts
@@ -1,15 +1,13 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as cp from 'child_process';
-import ChildProcess = cp.ChildProcess;
 import { ILogger } from '../../logging';
 import { reporter } from '../../telemetry/telemetry';
 import * as messages from '../../messages';
 
-export class pdkNewTaskCommand {
-  private logger: ILogger = undefined;
-  private terminal: vscode.Terminal = undefined;
+export class PDKNewTaskCommand {
+  private logger: ILogger;
+  private terminal: vscode.Terminal;
 
   constructor(logger: ILogger, terminal: vscode.Terminal) {
     this.logger = logger;
@@ -33,6 +31,5 @@ export class pdkNewTaskCommand {
 
   public dispose(): any {
     this.terminal.dispose();
-    this.terminal = undefined;
   }
 }

--- a/src/commands/pdk/pdkTestCommand.ts
+++ b/src/commands/pdk/pdkTestCommand.ts
@@ -1,15 +1,13 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as cp from 'child_process';
-import ChildProcess = cp.ChildProcess;
 import { ILogger } from '../../logging';
 import { reporter } from '../../telemetry/telemetry';
 import * as messages from '../../messages';
 
-export class pdkTestUnitCommand {
-  private logger: ILogger = undefined;
-  private terminal: vscode.Terminal = undefined;
+export class PDKTestUnitCommand {
+  private logger: ILogger;
+  private terminal: vscode.Terminal;
 
   constructor(logger: ILogger, terminal: vscode.Terminal) {
     this.logger = logger;
@@ -26,6 +24,5 @@ export class pdkTestUnitCommand {
 
   public dispose(): any {
     this.terminal.dispose();
-    this.terminal = undefined;
   }
 }

--- a/src/commands/pdk/pdkValidateCommand.ts
+++ b/src/commands/pdk/pdkValidateCommand.ts
@@ -1,15 +1,13 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as cp from 'child_process';
-import ChildProcess = cp.ChildProcess;
 import { ILogger } from '../../logging';
 import { reporter } from '../../telemetry/telemetry';
 import * as messages from '../../messages';
 
-export class pdkValidateCommand {
-  private logger: ILogger = undefined;
-  private terminal: vscode.Terminal = undefined;
+export class PDKValidateCommand {
+  private logger: ILogger;
+  private terminal: vscode.Terminal;
 
   constructor(logger: ILogger, terminal: vscode.Terminal) {
     this.logger = logger;
@@ -26,6 +24,5 @@ export class pdkValidateCommand {
 
   public dispose(): any {
     this.terminal.dispose();
-    this.terminal = undefined;
   }
 }

--- a/src/commands/pdkcommands.ts
+++ b/src/commands/pdkcommands.ts
@@ -2,14 +2,14 @@ import * as vscode from 'vscode';
 import * as messages from '../../src/messages';
 import { IConnectionManager } from '../../src/connection';
 import { ILogger } from '../../src/logging';
-import { pdkNewModuleCommand } from './pdk/pdkNewModuleCommand';
+import { PDKNewModuleCommand } from './pdk/pdkNewModuleCommand';
 import { PDKNewClassCommand } from './pdk/pdkNewClassCommand';
 import { pdkNewTaskCommand } from './pdk/pdkNewTaskCommand';
 import { pdkValidateCommand } from './pdk/pdkValidateCommand';
 import { pdkTestUnitCommand } from './pdk/pdkTestCommand';
 
 export function setupPDKCommands(langID: string, connManager: IConnectionManager, ctx: vscode.ExtensionContext, logger: ILogger, terminal: vscode.Terminal) {
-  let newModuleCommand = new pdkNewModuleCommand(logger, terminal);
+  let newModuleCommand = new PDKNewModuleCommand(logger, terminal);
   ctx.subscriptions.push(newModuleCommand);
   ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkNewModuleCommandId, () => {
     newModuleCommand.run();

--- a/src/commands/pdkcommands.ts
+++ b/src/commands/pdkcommands.ts
@@ -5,7 +5,7 @@ import { ILogger } from '../../src/logging';
 import { PDKNewModuleCommand } from './pdk/pdkNewModuleCommand';
 import { PDKNewClassCommand } from './pdk/pdkNewClassCommand';
 import { PDKNewTaskCommand } from './pdk/pdkNewTaskCommand';
-import { pdkValidateCommand } from './pdk/pdkValidateCommand';
+import { PDKValidateCommand } from './pdk/pdkValidateCommand';
 import { PDKTestUnitCommand } from './pdk/pdkTestCommand';
 
 export function setupPDKCommands(langID: string, connManager: IConnectionManager, ctx: vscode.ExtensionContext, logger: ILogger, terminal: vscode.Terminal) {
@@ -27,7 +27,7 @@ export function setupPDKCommands(langID: string, connManager: IConnectionManager
     newTaskCommand.run();
   }));
 
-  let validateCommand = new pdkValidateCommand(logger, terminal);
+  let validateCommand = new PDKValidateCommand(logger, terminal);
   ctx.subscriptions.push(validateCommand);
   ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkValidateCommandId, () => {
     validateCommand.run();

--- a/src/commands/pdkcommands.ts
+++ b/src/commands/pdkcommands.ts
@@ -6,7 +6,7 @@ import { PDKNewModuleCommand } from './pdk/pdkNewModuleCommand';
 import { PDKNewClassCommand } from './pdk/pdkNewClassCommand';
 import { PDKNewTaskCommand } from './pdk/pdkNewTaskCommand';
 import { pdkValidateCommand } from './pdk/pdkValidateCommand';
-import { pdkTestUnitCommand } from './pdk/pdkTestCommand';
+import { PDKTestUnitCommand } from './pdk/pdkTestCommand';
 
 export function setupPDKCommands(langID: string, connManager: IConnectionManager, ctx: vscode.ExtensionContext, logger: ILogger, terminal: vscode.Terminal) {
   let newModuleCommand = new PDKNewModuleCommand(logger, terminal);
@@ -33,7 +33,7 @@ export function setupPDKCommands(langID: string, connManager: IConnectionManager
     validateCommand.run();
   }));
 
-  let testUnitCommand = new pdkTestUnitCommand(logger, terminal);
+  let testUnitCommand = new PDKTestUnitCommand(logger, terminal);
   ctx.subscriptions.push(testUnitCommand);
   ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkTestUnitCommandId, () => {
     testUnitCommand.run();

--- a/src/commands/pdkcommands.ts
+++ b/src/commands/pdkcommands.ts
@@ -4,7 +4,7 @@ import { IConnectionManager } from '../../src/connection';
 import { ILogger } from '../../src/logging';
 import { PDKNewModuleCommand } from './pdk/pdkNewModuleCommand';
 import { PDKNewClassCommand } from './pdk/pdkNewClassCommand';
-import { pdkNewTaskCommand } from './pdk/pdkNewTaskCommand';
+import { PDKNewTaskCommand } from './pdk/pdkNewTaskCommand';
 import { pdkValidateCommand } from './pdk/pdkValidateCommand';
 import { pdkTestUnitCommand } from './pdk/pdkTestCommand';
 
@@ -21,7 +21,7 @@ export function setupPDKCommands(langID: string, connManager: IConnectionManager
     newClassCommand.run();
   }));
   
-  let newTaskCommand = new pdkNewTaskCommand(logger, terminal);
+  let newTaskCommand = new PDKNewTaskCommand(logger, terminal);
   ctx.subscriptions.push(newClassCommand);
   ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkNewTaskCommandId, () => {
     newTaskCommand.run();

--- a/src/commands/pdkcommands.ts
+++ b/src/commands/pdkcommands.ts
@@ -3,7 +3,7 @@ import * as messages from '../../src/messages';
 import { IConnectionManager } from '../../src/connection';
 import { ILogger } from '../../src/logging';
 import { pdkNewModuleCommand } from './pdk/pdkNewModuleCommand';
-import { pdkNewClassCommand } from './pdk/pdkNewClassCommand';
+import { PDKNewClassCommand } from './pdk/pdkNewClassCommand';
 import { pdkNewTaskCommand } from './pdk/pdkNewTaskCommand';
 import { pdkValidateCommand } from './pdk/pdkValidateCommand';
 import { pdkTestUnitCommand } from './pdk/pdkTestCommand';
@@ -15,7 +15,7 @@ export function setupPDKCommands(langID: string, connManager: IConnectionManager
     newModuleCommand.run();
   }));
 
-  let newClassCommand = new pdkNewClassCommand(logger, terminal);
+  let newClassCommand = new PDKNewClassCommand(logger, terminal);
   ctx.subscriptions.push(newClassCommand);
   ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkNewClassCommandId, () => {
     newClassCommand.run();

--- a/src/commands/puppetcommands.ts
+++ b/src/commands/puppetcommands.ts
@@ -6,12 +6,12 @@ import {
   PuppetNodeGraphContentProvider, isNodeGraphFile,
   getNodeGraphUri, showNodeGraph
 } from '../../src/providers/previewNodeGraphProvider';
-import { puppetResourceCommand } from '../commands/puppet/puppetResourceCommand';
+import { PuppetResourceCommand } from '../commands/puppet/puppetResourceCommand';
 import { PuppetFormatDocumentProvider } from '../providers/puppetFormatDocumentProvider';
 
 export function setupPuppetCommands(langID:string, connManager:IConnectionManager, ctx:vscode.ExtensionContext, logger: ILogger){
 
-  let resourceCommand = new puppetResourceCommand(connManager, logger);
+  let resourceCommand = new PuppetResourceCommand(connManager, logger);
   ctx.subscriptions.push(resourceCommand);
   ctx.subscriptions.push(vscode.commands.registerCommand(messages.PuppetCommandStrings.PuppetResourceCommandId, () => {
     resourceCommand.run();


### PR DESCRIPTION
This PR fixes tslint errors in all of the PDK and Puppet VSCode command pallette commands.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/jpogran/puppet-vscode/blob/master/CONTRIBUTING.md

and

CODE_OF_CONDUCT - https://github.com/jpogran/puppet-vscode/blob/master/CODE_OF_CONDUCT.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->