### PR TITLE
(maint) Update options for DebugAdapter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,15 @@
       "preLaunchTask": "npm: watch"
     },
     {
+      "type": "node",
+      "request": "launch",
+      "name": "DebugAdapter",
+      "cwd": "${workspaceFolder}",
+      "program": "${workspaceFolder}/src/debugAdapter.ts",
+      "args": [ "--server=4711" ],
+      "outFiles": [ "${workspaceFolder}/out/**/*.js" ]
+    },
+    {
       "name": "Extension Tests",
       "type": "extensionHost",
       "request": "launch",
@@ -31,6 +40,12 @@
         "${workspaceFolder}/out/test/**/*.js"
       ],
       "preLaunchTask": "npm: watch"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Extension + DebugAdapter",
+      "configurations": [ "Extension", "DebugAdapter" ]
     }
   ]
 }


### PR DESCRIPTION
Previously it was difficult to debug the DebugAdapter as it it run out of
process from the extension.  This commit adds two new launch configurations
which will assist developers running the DebugAdapter in debug mode, allowing
VSCode to enter the adapter via breakpoints etc.

References;
* https://code.visualstudio.com/docs/extensions/example-debuggers#_development-setup-for-mock-debug
* https://github.com/Microsoft/vscode-mock-debug/blob/master/.vscode/launch.json
