### PR TITLE
(GH-284) Added support for #region folding

### DIFF
--- a/languages/puppet.configuration.json
+++ b/languages/puppet.configuration.json
@@ -26,5 +26,13 @@
     ["(", ")"],
     ["\"", "\""],
     ["'", "'"]
-  ]
+  ],
+  // support for region folding
+  "folding": {
+		"offSide": true,
+		"markers": {
+			"start": "^\\s*#\\s*region\\b",
+			"end": "^\\s*#\\s*endregion\\b"
+		}
+	}
 }


### PR DESCRIPTION
Hello, as I mentioned in https://github.com/lingua-pupuli/puppet-vscode/issues/284, I would really like to see `#region` folding support for puppet manifests, this change adapted from https://github.com/Microsoft/vscode-python/issues/33 should handle that. 
