### PR TITLE
(maint) Update Puppet grammar file

### DIFF
--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -765,6 +765,10 @@
           <key>include</key>
           <string>#parameter-default-types</string>
         </dict>
+        <dict>
+          <key>include</key>
+          <string>#line_comment</string>
+        </dict>
       </array>
     </dict>
     <key>hash</key>


### PR DESCRIPTION
This commit updates the puppet grammar file to the latest commit
https://github.com/lingua-pupuli/puppet-editor-syntax/commit/633142c3343d952e55e7ddf47af26fca97808c45
