### PR TITLE
(maint) Automatically download vendored items on watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 // Include gulp
+var es = require('event-stream');
 var gulp = require('gulp');
 var del = require('del');
 var runSequence = require('run-sequence');
@@ -38,9 +39,23 @@ function getEditorServicesReleaseURL(config) {
 // The default task (called when you run `gulp` from cli)
 gulp.task('default', ['build']);
 
+gulp.task('initial', function (callback) {
+  var fs = require('fs');
+  var sequence = [];
+
+  editorServicesPath = path.join(__dirname, 'vendor', 'languageserver');
+  if (!fs.existsSync(editorServicesPath)) { sequence.push('vendor_editor_services'); }
+
+  if (sequence.length > 0) {
+    return runSequence(sequence, callback);
+  } else {
+    return es.merge([]);
+  }
+});
+
 gulp.task('clean', function () {
   return del(['vendor'])
-})
+});
 
 gulp.task('vendor_editor_services', function (callback) {
   var config = getEditorServicesConfig();

--- a/package.json
+++ b/package.json
@@ -393,7 +393,7 @@
   "scripts": {
     "vscode:prepublish": "node node_modules/gulp/bin/gulp.js build",
     "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./",
+    "watch": "node node_modules/gulp/bin/gulp.js initial && tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "npm run compile && node ./node_modules/vscode/bin/test"
   },


### PR DESCRIPTION
Previously you had to remember to vendor the editor services before running the
extension during development.  This commit changes the npm watch task, to first
run the new npm intial task, which downloads vendored assets, if they don't
already exist.

