### PR TITLE
(maint) Improve the Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_issue_template.md
@@ -1,0 +1,18 @@
+---
+name: Feature request or new idea ✨
+about: Suggest a new feature or something you would like see
+
+---
+
+**Summary of the new feature**
+
+A clear and concise description of what the problem is that the new feature would solve.
+
+For example:
+
+---
+**As a** user
+
+**I would like to** automatically format my puppet manifests
+
+**so that I** don't have to remember to do it myself.

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,3 +1,8 @@
+---
+name: Bug report 🐞
+about: Report an error or unexpected behavior
+
+---
 <!-- 
 Thanks for taking the time to reach out to us!
 

--- a/.github/ISSUE_TEMPLATE/puppet_lint_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/puppet_lint_issue_template.md
@@ -1,0 +1,7 @@
+---
+name: Puppet lint bug report ⛔️
+about: Puppet lint issues are tracked in a separate GitHub repo.
+
+---
+
+* Please submit puppet lint issues to the [Puppet Lint](https://github.com/rodjek/puppet-lint) repo on GitHub.

--- a/.github/ISSUE_TEMPLATE/syntax_color_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/syntax_color_issue_template.md
@@ -1,0 +1,7 @@
+---
+name: Syntax Colorization bug report 🌈
+about: Puppet syntax colorization issues are tracked in a separate GitHub repo.
+
+---
+
+* Please submit editor syntax colorization issues with Puppet files to the [Puppet Editor Syntax](https://github.com/lingua-pupuli/puppet-editor-syntax) repo on GitHub.


### PR DESCRIPTION
Previously there was only one github issue template, however github does support
multiple.  This commit adds 3 additional templates to help directory issues to
the correct location.
