### PR TITLE
(GH-241) Honor specified tcp port

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,7 +300,6 @@
         },
         "puppet.languageserver.port": {
           "type": "integer",
-          "default": 8081,
           "description": "The TCP Port of the Puppet Language Server to connect to"
         },
         "puppet.languageserver.timeout": {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -182,23 +182,28 @@ export class ConnectionManager implements IConnectionManager {
 
     let connMgr: ConnectionManager = this;
     if(this.connectionConfiguration.protocol === ProtocolType.TCP){
-      // Start a server to get a random port
-      this.logger.debug(logPrefix + 'Creating server process to identify random port');
-      const server = net
-        .createServer()
-        .on('close', () => {
-          this.logger.debug(logPrefix + 'Server process to identify random port disconnected');
-          connMgr.startLanguageServerProcess(localServer.command, localServer.args, localServer.options, callback);
-        })
-        .on('error', err => {
-          throw err;
-        });
+      if(this.connectionConfiguration.port){
+        this.logger.debug(logPrefix + 'Selected port for local language server: ' + this.connectionConfiguration.port);
+        connMgr.startLanguageServerProcess(localServer.command, localServer.args, localServer.options, callback);
+      }else{
+        // Start a server to get a random port
+        this.logger.debug(logPrefix + 'Creating server process to identify random port');
+        const server = net
+          .createServer()
+          .on('close', () => {
+            this.logger.debug(logPrefix + 'Server process to identify random port disconnected');
+            connMgr.startLanguageServerProcess(localServer.command, localServer.args, localServer.options, callback);
+          })
+          .on('error', err => {
+            throw err;
+          });
 
-      // Listen on random port
-      server.listen(0);
-      this.logger.debug(logPrefix + 'Selected port for local language server: ' + server.address().port);
-      connMgr.connectionConfiguration.port = server.address().port;
-      server.close();
+        // Listen on random port
+        server.listen(0);
+        this.logger.debug(logPrefix + 'Selected port for local language server: ' + server.address().port);
+        connMgr.connectionConfiguration.port = server.address().port;
+        server.close();
+      }
     }else{
       this.logger.debug(logPrefix + 'STDIO Server process starting');
       connMgr.startLanguageServerProcess(localServer.command, localServer.args, localServer.options, callback);


### PR DESCRIPTION
This PR fixes the logic that decides what port to connect to the LanguageServer on. Previously it would always pick a random unused port to start and connect to the language server, now it will use the port specified in the configuration if it is there.