### PR TITLE
(GH-301) Fail fast if no agent installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ get notified automatically about any future extension updates!
 
 ## Experience a Problem?
 
+### Puppet Agent Install
+
+A commonly encountered problem is not having Puppet Agent installed on the computer you are running VSCode on. As noted in the [Requirements section](https://github.com/lingua-pupuli/puppet-vscode/blob/master/README.md#requirements), you will need to have Puppet Agent installed in order to fully use this extension, as the extension uses the Puppet binaries and the Ruby language bundled into the agent install in order to function.
+
+If you are receiving an error right after opening a Puppet file saying that a Puppet Agent install could not be found, ensure that Puppet is installed on the system. The VSCode extension attempts to find a valid Puppet install if a path is not configured in `puppet.puppetAgentDir` in `User Settings`, so if Puppet is installed but not in a default path please check that your setting points to the correct path.
+
+### Reloading the Puppet VSCode extension
+
 If you haven't see the Problems Pane update in awhile, or hover and intellisense doesn't seem to showing up, and you might not know what to do. Sometimes the Puppet extension can experience problems which cause the language server to crash or not respond. The extension has a way of logging the crash, but there is something you can do to get right back to working: reload the Puppet Language Server.
 
 You can reload the Puppet Lanuguage Server by opening the command palette and starting to type `Puppet`. A list of Puppet commands will appear, select `Puppet: Restart Current Session`. This will restart the Puppet Language Server without reloading VSCode or losing any work currently open in the editor.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 
 import { ConnectionManager } from './connection';
 import { ConnectionConfiguration } from './configuration';
@@ -25,9 +26,34 @@ export function activate(context: vscode.ExtensionContext) {
   var logger = new OutputChannelLogger();
   var statusBar = new PuppetStatusBar(langID);
   var configSettings = new ConnectionConfiguration(context);
-  
-  connManager = new ConnectionManager(context, logger, statusBar, configSettings);
 
+  if (!fs.existsSync(configSettings.puppetDir)) {
+    logger.error('Could not find a valid Puppet installation at ' + configSettings.puppetDir);
+    vscode.window
+      .showErrorMessage(
+        `Could not find a valid Puppet installation at '${
+          configSettings.puppetDir
+        }'. While syntax highlighting and grammar detection will still work, intellisense and other advanced features will not.`,
+        { modal: false },
+        { title: 'Troubleshooting Information' }
+      )
+      .then(item => {
+        if (item === undefined) {
+          return;
+        }
+        if (item.title === 'Troubleshooting Information') {
+          vscode.commands.executeCommand(
+            'vscode.open',
+            vscode.Uri.parse('https://github.com/lingua-pupuli/puppet-vscode#experience-a-problem')
+          );
+        }
+      });
+    return null;
+  } else {
+    logger.debug('Found a valid Puppet installation at ' + configSettings.puppetDir);
+  }
+
+  connManager = new ConnectionManager(context, logger, statusBar, configSettings);
 
   if (!commandsRegistered) {
     logger.debug('Configuring commands');
@@ -35,10 +61,9 @@ export function activate(context: vscode.ExtensionContext) {
     setupPuppetCommands(langID, connManager, context, logger);
 
     terminal = vscode.window.createTerminal('Puppet PDK');
-    terminal.processId.then(
-      pid => {
-        logger.debug("pdk shell started, pid: " + pid);
-      });
+    terminal.processId.then(pid => {
+      logger.debug('pdk shell started, pid: ' + pid);
+    });
     setupPDKCommands(langID, connManager, context, logger, terminal);
     context.subscriptions.push(terminal);
 


### PR DESCRIPTION
This PR adds logic to check if there is a valid Puppet Agent binary
file path configured at extension load. It will then throw an
informative error if there isn't a binary found so the user knows what
won't work without an agent.

Previously if the extension couldn't find a Puppet Agent installation or
was configured with an incorrect path, the extension silently failed to
load the language server and there wasn't much indication you're in a
broken state.