### PR TITLE
(GH-310) Fix gulp bump

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,6 +40,17 @@
         "${workspaceFolder}/out/test/**/*.js"
       ],
       "preLaunchTask": "npm: watch"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Gulp task",
+      "program": "${workspaceFolder}/node_modules/gulp/bin/gulp.js",
+      "args": [
+        // Add arguments here to debug gulp tasks
+        // "bump", "--type", "minor"
+        // "bump", "--specific", "99.99.0-appv.127"
+      ]
     }
   ],
   "compounds": [

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
        & npm install --silent
 
        Write-Host "Set the package.json version..."
-       & node node_modules\gulp\bin\gulp.js bump --version $ENV:APPVEYOR_BUILD_VERSION
+       & node node_modules\gulp\bin\gulp.js bump --specific $ENV:APPVEYOR_BUILD_VERSION
      }
 
 build_script:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,7 +132,7 @@ gulp.task('bump', function () {
     /// Usage:
     /// 1. gulp bump : bumps the package.json and bower.json to the next minor revision.
     ///   i.e. from 0.1.1 to 0.1.2
-    /// 2. gulp bump --version 1.1.1 : bumps/sets the package.json and bower.json to the
+    /// 2. gulp bump --specific 1.1.1 : bumps/sets the package.json and bower.json to the
     ///    specified revision.
     /// 3. gulp bump --type major       : bumps 1.0.0
     ///    gulp bump --type minor       : bumps 0.1.0
@@ -141,7 +141,7 @@ gulp.task('bump', function () {
     /// </summary>
 
     var type = args.type;
-    var version = args.version;
+    var version = args.specific;
     var options = {};
     if (version) {
         options.version = version;


### PR DESCRIPTION
This PR fixes bumping the version of the extension in package.json by changing the parameter name used to specify version. It appears version is already used by the yargs package (https://github.com/yargs/yargs/blob/master/docs/api.md#versionoption-description-version) which returns the version of the yargs package instead of what you supplied.

This PR successfully makes a versioned vsix in appveyor: https://ci.appveyor.com/api/buildjobs/yeg6k3q119arvqwn/artifacts/puppet-vscode-99.99.0-appv.134.vsix

Fixes #310 