### PR TITLE
(maint) Update package-lock with 0.11.0 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-vscode",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
In the 0.11.0 release, the package-lock.json file was left out. This
commit updates the file with the correct version.