### PR TITLE
(GH-315) PDKIFY ALL THE THINGS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ language: cpp
 
 os:
   - linux
-# Do we actually need to run this on OSX?
-# OSX is REALLY slow to test
-#  - osx
+  - osx
 
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
       "type": "object",
       "title": "puppet",
       "properties": {
-        "puppet.puppetAgentDir": {
+        "puppet.installDirectory": {
           "type": "string",
           "default": null,
           "description": "The fully qualified path to the Puppet agent install directory. For example: 'C:\\Program Files\\Puppet Labs\\Puppet' or '/opt/puppetlabs/puppet'"

--- a/package.json
+++ b/package.json
@@ -267,6 +267,15 @@
       "type": "object",
       "title": "puppet",
       "properties": {
+        "puppet.installType": { 
+          "type": "string",
+          "default": "pdk",
+          "description": "The Puppet Install Type",
+          "enum": [
+            "pdk",
+            "puppet"
+          ]
+        },
         "puppet.installDirectory": {
           "type": "string",
           "default": null,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,10 +15,8 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
   public langID: string = 'puppet'; // don't change this
 
   config: vscode.WorkspaceConfiguration;
-  context: vscode.ExtensionContext;
 
-  constructor(context: vscode.ExtensionContext) {
-    this.context = context;
+  constructor() {
     this.config = vscode.workspace.getConfiguration('puppet');
 
     this.host = this.config['languageserver']['address'];
@@ -134,7 +132,7 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
   }
 
   get languageServerPath(): string {
-    return this.context.asAbsolutePath(path.join('vendor', 'languageserver', 'puppet-languageserver'));
+    return path.join('vendor', 'languageserver', 'puppet-languageserver');
   }
 
   get type(): ConnectionType {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -27,8 +27,8 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
   }
 
   get puppetBaseDir(): string {
-    if (this.config['puppetAgentDir'] !== null) {
-      return this.config['puppetAgentDir'];
+    if (this.config['installDirectory'] !== null) {
+      return this.config['installDirectory'];
     }
 
     switch (process.platform) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -42,16 +42,33 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
       return this.config['installDirectory'];
     }
 
-    switch (process.platform) {
-      case 'win32':
-        let programFiles = PathResolver.getprogramFiles();
-        // On Windows we have a subfolder called 'Puppet' that has
-        // every product underneath
-        return path.join(programFiles, 'Puppet Labs', 'Puppet');
-      default:
-        // On *nix we don't have a sub folder called 'Puppet'
-        return '/opt/puppetlabs';
-    }
+    let programFiles = PathResolver.getprogramFiles(); 
+    switch(this.puppetInstallType){ 
+      case PuppetInstallType.PDK: 
+        switch (process.platform) { 
+          case 'win32': 
+            return path.join(programFiles, 'Puppet Labs', 'DevelopmentKit'); 
+          default: 
+            return path.join(programFiles, 'puppetlabs', 'pdk'); 
+        }
+      case PuppetInstallType.PUPPET: 
+        switch (process.platform) { 
+          case 'win32': 
+            // On Windows we have a subfolder called 'Puppet' that has 
+            // every product underneath 
+            return path.join(programFiles, 'Puppet Labs', 'Puppet'); 
+          default: 
+            // On *nix we don't have a sub folder called 'Puppet' 
+            return path.join(programFiles, 'puppetlabs'); 
+        } 
+      default:         
+        switch (process.platform) { 
+          case 'win32': 
+            return path.join(programFiles, 'Puppet Labs', 'DevelopmentKit'); 
+          default: 
+            return path.join(programFiles, 'puppetlabs', 'pdk'); 
+        } 
+    } 
   }
 
   get pdkDir(): string {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 
 import { IConnectionConfiguration, ConnectionType, ProtocolType, PuppetInstallType } from './interfaces';
+import { PathResolver } from './configuration/pathResolver';
 
 export class ConnectionConfiguration implements IConnectionConfiguration {
   public host: string;
@@ -43,10 +44,7 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
 
     switch (process.platform) {
       case 'win32':
-        let programFiles = process.env['ProgramFiles'] || 'C:\\Program Files';
-        if (process.env['PROCESSOR_ARCHITEW6432'] === 'AMD64') {
-          programFiles = process.env['ProgramW6432'] || 'C:\\Program Files';
-        }
+        let programFiles = PathResolver.getprogramFiles();
         // On Windows we have a subfolder called 'Puppet' that has
         // every product underneath
         return path.join(programFiles, 'Puppet Labs', 'Puppet');
@@ -112,7 +110,7 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
       path.join(this.puppetDir, 'lib'),
       path.join(this.facterDir, 'lib'),
       // path.join(this.hieraDir, 'lib'),
-    ).join(this.pathEnvSeparator());
+    ).join(PathResolver.pathEnvSeparator());
 
     if (process.platform === 'win32') {
       // Translate all slashes to / style to avoid puppet/ruby issue #11930
@@ -131,7 +129,7 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
       path.join(this.puppetBaseDir, 'bin'),
       path.join(this.rubydir, 'bin'),
       path.join(this.puppetBaseDir, 'sys', 'tools', 'bin')
-    ).join(this.pathEnvSeparator());
+    ).join(PathResolver.pathEnvSeparator());
   }
 
   get languageServerPath(): string {
@@ -193,13 +191,5 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
     }
 
     return args;
-  }
-
-  pathEnvSeparator() {
-    if (process.platform === 'win32') {
-      return ';';
-    } else {
-      return ':';
-    }
   }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -13,6 +13,7 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
   public enableFileCache: boolean;
   public debugFilePath: string;
   public langID: string = 'puppet'; // don't change this
+
   config: vscode.WorkspaceConfiguration;
   context: vscode.ExtensionContext;
 
@@ -29,62 +30,45 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
     this._puppetInstallType = this.config['installType']
   }
 
-  private _puppetInstallType : PuppetInstallType;
-  public get puppetInstallType() : PuppetInstallType {
+  private _puppetInstallType: PuppetInstallType;
+  public get puppetInstallType(): PuppetInstallType {
     return this._puppetInstallType;
   }
-  public set puppetInstallType(v : PuppetInstallType) {
+  public set puppetInstallType(v: PuppetInstallType) {
     this._puppetInstallType = v;
   }
-  
+
   get puppetBaseDir(): string {
     if (this.config['installDirectory'] !== null) {
       return this.config['installDirectory'];
     }
 
-    let programFiles = PathResolver.getprogramFiles(); 
-    switch(this.puppetInstallType){ 
-      case PuppetInstallType.PDK: 
-        switch (process.platform) { 
-          case 'win32': 
-            return path.join(programFiles, 'Puppet Labs', 'DevelopmentKit'); 
-          default: 
-            return path.join(programFiles, 'puppetlabs', 'pdk'); 
+    let programFiles = PathResolver.getprogramFiles();
+    switch (this.puppetInstallType) {
+      case PuppetInstallType.PDK:
+        switch (process.platform) {
+          case 'win32':
+            return path.join(programFiles, 'Puppet Labs', 'DevelopmentKit');
+          default:
+            return path.join(programFiles, 'puppetlabs', 'pdk');
         }
-      case PuppetInstallType.PUPPET: 
-        switch (process.platform) { 
-          case 'win32': 
+      case PuppetInstallType.PUPPET:
+        switch (process.platform) {
+          case 'win32':
             // On Windows we have a subfolder called 'Puppet' that has 
             // every product underneath 
-            return path.join(programFiles, 'Puppet Labs', 'Puppet'); 
-          default: 
+            return path.join(programFiles, 'Puppet Labs', 'Puppet');
+          default:
             // On *nix we don't have a sub folder called 'Puppet' 
-            return path.join(programFiles, 'puppetlabs'); 
-        } 
-      default:         
-        switch (process.platform) { 
-          case 'win32': 
-            return path.join(programFiles, 'Puppet Labs', 'DevelopmentKit'); 
-          default: 
-            return path.join(programFiles, 'puppetlabs', 'pdk'); 
-        } 
-    } 
-  }
-
-  get pdkDir(): string {
-    if (this.config['pdkDir'] !== null) {
-      return this.config['pdkDir'];
-    }
-
-    switch (process.platform) {
-      case 'win32':
-        let programFiles = process.env['ProgramFiles'] || 'C:\\Program Files';
-        if (process.env['PROCESSOR_ARCHITEW6432'] === 'AMD64') {
-          programFiles = process.env['ProgramW6432'] || 'C:\\Program Files';
+            return path.join(programFiles, 'puppetlabs');
         }
-        return path.join(programFiles, 'Puppet Labs', 'DevelopmentKit');
       default:
-        return '/opt/puppetlabs/pdk';
+        switch (process.platform) {
+          case 'win32':
+            return path.join(programFiles, 'Puppet Labs', 'DevelopmentKit');
+          default:
+            return path.join(programFiles, 'puppetlabs', 'pdk');
+        }
     }
   }
 
@@ -105,11 +89,11 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
   }
 
   get rubydir(): string {
-    switch(process.platform){
+    switch (process.platform) {
       case 'win32':
         return path.join(this.puppetBaseDir, 'sys', 'ruby');
       default:
-        return path.join(this.puppetBaseDir, 'lib', 'ruby');      
+        return path.join(this.puppetBaseDir, 'lib', 'ruby');
     }
   }
 
@@ -194,7 +178,7 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
     }
 
     args.push('--timeout=' + this.timeout);
-  
+
     if (vscode.workspace.workspaceFolders !== undefined) {
       args.push('--local-workspace=' + vscode.workspace.workspaceFolders[0].uri.fsPath);
     }
@@ -209,4 +193,58 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
 
     return args;
   }
+
+  get pdkBinDir(): string {
+    return path.join(this.puppetBaseDir, 'bin');
+  }
+
+  get pdkRubyLib(): string {
+    var lib = path.join(this.puppetBaseDir, 'lib');
+    if (process.platform === 'win32') {
+      // Translate all slashes to / style to avoid puppet/ruby issue #11930
+      lib = lib.replace(/\\/g, '/');
+    }
+    return lib;
+  }
+
+  get pdkRubyVerDir(): string {
+    var rootDir = path.join(this.puppetBaseDir, 'private', 'puppet', 'ruby');
+    var versionDir = '2.4.0';
+
+    return PathResolver.resolveSubDirectory(rootDir, versionDir);
+  }
+
+  get pdkGemDir(): string {
+    // GEM_HOME=C:\Users\user\AppData\Local/PDK/cache/ruby/2.4.0
+    var rootDir = path.join(this.puppetBaseDir, 'share', 'cache', 'ruby');
+    var versionDir = '2.4.0';
+    var directory = PathResolver.resolveSubDirectory(rootDir, versionDir);
+
+    if (process.platform === 'win32') {
+      // Translate all slashes to / style to avoid puppet/ruby issue #11930
+      directory = directory.replace(/\\/g, '/');
+    }
+    return directory;
+  }
+
+  get pdkRubyDir(): string {
+    var rootDir = path.join(this.puppetBaseDir, 'private', 'ruby');
+    var versionDir = '2.4.4';
+
+    return PathResolver.resolveSubDirectory(rootDir, versionDir);
+  }
+
+  get pdkRubyBinDir(): string {
+    return path.join(this.pdkRubyDir, 'bin');
+  }
+
+  get pdkGemVerDir(): string {
+    var rootDir = path.join(this.pdkRubyDir, 'lib', 'ruby', 'gems');
+    var versionDir = '2.4.0';
+
+    return PathResolver.resolveSubDirectory(rootDir, versionDir);
+  }
+
+  // GEM_PATH=C:/Program Files/Puppet Labs/DevelopmentKit/private/ruby/2.4.4/lib/ruby/gems/2.4.0;C:/Program Files/Puppet Labs/DevelopmentKit/share/cache/ruby/2.4.0;C:/Program Files/Puppet Labs/DevelopmentKit/private/puppet/ruby/2.4.0
+
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -3,7 +3,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 
-import { IConnectionConfiguration, ConnectionType, ProtocolType } from './interfaces';
+import { IConnectionConfiguration, ConnectionType, ProtocolType, PuppetInstallType } from './interfaces';
 
 export class ConnectionConfiguration implements IConnectionConfiguration {
   public host: string;
@@ -24,8 +24,18 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
     this.timeout = this.config['languageserver']['timeout'];
     this.enableFileCache = this.config['languageserver']['filecache']['enable'];
     this.debugFilePath = this.config['languageserver']['debugFilePath'];
+
+    this._puppetInstallType = this.config['installType']
   }
 
+  private _puppetInstallType : PuppetInstallType;
+  public get puppetInstallType() : PuppetInstallType {
+    return this._puppetInstallType;
+  }
+  public set puppetInstallType(v : PuppetInstallType) {
+    this._puppetInstallType = v;
+  }
+  
   get puppetBaseDir(): string {
     if (this.config['installDirectory'] !== null) {
       return this.config['installDirectory'];

--- a/src/configuration/pathResolver.ts
+++ b/src/configuration/pathResolver.ts
@@ -1,0 +1,26 @@
+export class PathResolver {
+
+  public static getprogramFiles(): string {
+    switch (process.platform) {
+      case 'win32':
+        let programFiles = process.env['ProgramFiles'] || 'C:\\Program Files';
+
+        if (process.env['PROCESSOR_ARCHITEW6432'] === 'AMD64') {
+          programFiles = process.env['ProgramW6432'] || 'C:\\Program Files';
+        }
+        return programFiles;
+
+      default:
+        return '/opt';
+    }
+  }
+
+  public static pathEnvSeparator() {
+    if (process.platform === 'win32') {
+      return ';';
+    } else {
+      return ':';
+    }
+  }
+
+}

--- a/src/configuration/pathResolver.ts
+++ b/src/configuration/pathResolver.ts
@@ -1,3 +1,6 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
 export class PathResolver {
 
   public static getprogramFiles(): string {
@@ -13,6 +16,23 @@ export class PathResolver {
       default:
         return '/opt';
     }
+  }
+
+  public static resolveSubDirectory(rootDir: string, subDir: string) {
+    var versionDir = path.join(rootDir, subDir);
+
+    if (fs.existsSync(versionDir)) {
+      return versionDir;
+    } else {
+      var subdir = PathResolver.getDirectories(rootDir)[1];
+      return subdir;
+    }
+  }
+
+  public static getDirectories(parent: string) {
+    return fs.readdirSync(parent).filter(function (file) {
+      return fs.statSync(path.join(parent, file)).isDirectory();
+    });
   }
 
   public static pathEnvSeparator() {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -174,9 +174,7 @@ export class ConnectionManager implements IConnectionManager {
       command: string;
       args: string[];
       options: cp.SpawnOptions;
-    } = RubyHelper.getRubyEnvFromPuppetAgent(serverExe, this.connectionConfiguration, this.logger);
-    // Commented out for the moment.  This will be enabled once the configuration and exact user story is figured out.
-    //if (localServer == null) { localServer = RubyHelper.getRubyEnvFromPDK(serverExe, this.connectionConfiguration, this.logger); }
+    } = RubyHelper.getRubyEnvFromConfiguration(serverExe, this.connectionConfiguration, this.logger);
 
     if (localServer === null) {
       this.logger.warning(logPrefix + 'Could not find a valid Puppet Agent installation');

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -176,15 +176,6 @@ export class ConnectionManager implements IConnectionManager {
       options: cp.SpawnOptions;
     } = RubyHelper.getRubyEnvFromConfiguration(serverExe, this.connectionConfiguration, this.logger);
 
-    if (localServer === null) {
-      this.logger.warning(logPrefix + 'Could not find a valid Puppet Agent installation');
-      this.setSessionFailure('Could not find a valid Puppet Agent installation');
-      vscode.window.showWarningMessage(
-        'Could not find a valid Puppet Agent installation. Functionality will be limited to syntax highlighting'
-      );
-      return;
-    }
-
     let connMgr: ConnectionManager = this;
     if(this.connectionConfiguration.protocol === ProtocolType.TCP){
       if(this.connectionConfiguration.port){

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -62,7 +62,7 @@ export class ConnectionManager implements IConnectionManager {
 
     if (this.connectionConfiguration.type === ConnectionType.Local) {
       this.createLanguageServerProcess(
-        this.connectionConfiguration.languageServerPath,
+        this.extensionContext.asAbsolutePath(this.connectionConfiguration.languageServerPath),
         this.onLanguageServerStart.bind(this)
       );
     } else {
@@ -316,7 +316,7 @@ export class ConnectionManager implements IConnectionManager {
 
   public restartConnection(connectionConfig?: IConnectionConfiguration) {
     if (connectionConfig === undefined) {
-      connectionConfig = new ConnectionConfiguration(this.extensionContext);
+      connectionConfig = new ConnectionConfiguration();
     }
     this.stop();
     this.start(connectionConfig);

--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -151,7 +151,7 @@ function startDebugServer(config:DebugConfiguration, debugLogger: ILogger) {
   // TODO use argv to pass in stuff?
   localServer = RubyHelper.getRubyEnvFromConfiguration(rubyfile, config, debugLogger);
 
-  if (localServer === null) {
+  if (!fs.existsSync(config.puppetBaseDir)) {
     sendErrorMessage("Unable to find a valid ruby environment");
     process.exit(255);
   }

--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -8,7 +8,7 @@ import cp = require('child_process');
 import { NullLogger } from './logging/null';
 import { ILogger } from './logging';
 import { RubyHelper } from './rubyHelper';
-import { IConnectionConfiguration, ConnectionType, ProtocolType } from './interfaces';
+import { IConnectionConfiguration, ConnectionType, ProtocolType, PuppetInstallType } from './interfaces';
 
 // This code just marshalls the STDIN/STDOUT to a socket
 
@@ -46,7 +46,6 @@ class DebugConfiguration implements IConnectionConfiguration {
   environmentPath: string;
   sslCertFile: string;
   sslCertDir: string;
-  pdkDir: string;
   languageServerCommandLine: string[];
   public type: ConnectionType = ConnectionType.Local ;
   public host: string = "127.0.0.1";
@@ -54,6 +53,15 @@ class DebugConfiguration implements IConnectionConfiguration {
   public timeout: number = 10;
   public enableFileCache: boolean;// tslint:disable-line:semicolon
   public debugFilePath: string; // tslint:disable-line:semicolon
+
+  puppetInstallType:PuppetInstallType; 
+  pdkBinDir:string;
+  pdkRubyLib:string;
+  pdkRubyVerDir:string;
+  pdkGemDir:string;
+  pdkRubyDir:string;
+  pdkRubyBinDir:string;
+  pdkGemVerDir:string; 
 
   constructor() {
     this.type = ConnectionType.Local;
@@ -69,7 +77,6 @@ class DebugConfiguration implements IConnectionConfiguration {
     this.environmentPath ='';
     this.sslCertFile ='';
     this.sslCertDir ='';
-    this.pdkDir ='';
     this.languageServerCommandLine =[''];
     this.enableFileCache = false;
     this.debugFilePath = '';

--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -149,9 +149,7 @@ function startDebugServer(config:DebugConfiguration, debugLogger: ILogger) {
   }
 
   // TODO use argv to pass in stuff?
-  if (localServer === null) { localServer = RubyHelper.getRubyEnvFromPuppetAgent(rubyfile, config, debugLogger); }
-  // Commented out for the moment.  This will be enabled once the configuration and exact user story is figured out.
-  // if (localServer == null) { localServer = RubyHelper.getRubyEnvFromPDK(rubyfile, config, debugLogger); }
+  localServer = RubyHelper.getRubyEnvFromConfiguration(rubyfile, config, debugLogger);
 
   if (localServer === null) {
     sendErrorMessage("Unable to find a valid ruby environment");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(new Reporter(context));
   var logger = new OutputChannelLogger();
   var statusBar = new PuppetStatusBar(langID);
-  var configSettings = new ConnectionConfiguration(context);
+  var configSettings = new ConnectionConfiguration();
 
   if (!fs.existsSync(configSettings.puppetBaseDir)) {
     logger.error('Could not find a valid Puppet installation at ' + configSettings.puppetBaseDir);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,12 +27,12 @@ export function activate(context: vscode.ExtensionContext) {
   var statusBar = new PuppetStatusBar(langID);
   var configSettings = new ConnectionConfiguration(context);
 
-  if (!fs.existsSync(configSettings.puppetDir)) {
-    logger.error('Could not find a valid Puppet installation at ' + configSettings.puppetDir);
+  if (!fs.existsSync(configSettings.puppetBaseDir)) {
+    logger.error('Could not find a valid Puppet installation at ' + configSettings.puppetBaseDir);
     vscode.window
       .showErrorMessage(
         `Could not find a valid Puppet installation at '${
-          configSettings.puppetDir
+          configSettings.puppetBaseDir
         }'. While syntax highlighting and grammar detection will still work, intellisense and other advanced features will not.`,
         { modal: false },
         { title: 'Troubleshooting Information' }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -40,3 +40,8 @@ export interface IConnectionConfiguration {
   pdkDir: string;
   languageServerCommandLine: Array<string>;
 }
+
+export enum PuppetInstallType{
+  PDK    = "pdk",
+  PUPPET = "puppet",
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -37,9 +37,9 @@ export interface IConnectionConfiguration {
   environmentPath: string;
   sslCertFile: string;
   sslCertDir: string;
-  pdkDir: string;
-  languageServerCommandLine: Array<string>; puppetInstallType:PuppetInstallType; 
+  languageServerCommandLine: Array<string>;
 
+  puppetInstallType:PuppetInstallType; 
   pdkBinDir:string;
   pdkRubyLib:string;
   pdkRubyVerDir:string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -38,7 +38,15 @@ export interface IConnectionConfiguration {
   sslCertFile: string;
   sslCertDir: string;
   pdkDir: string;
-  languageServerCommandLine: Array<string>;
+  languageServerCommandLine: Array<string>; puppetInstallType:PuppetInstallType; 
+
+  pdkBinDir:string;
+  pdkRubyLib:string;
+  pdkRubyVerDir:string;
+  pdkGemDir:string;
+  pdkRubyDir:string;
+  pdkRubyBinDir:string;
+  pdkGemVerDir:string; 
 }
 
 export enum PuppetInstallType{

--- a/src/rubyHelper.ts
+++ b/src/rubyHelper.ts
@@ -2,148 +2,79 @@ import path = require('path');
 import fs = require('fs');
 import cp = require('child_process');
 import { ILogger } from './logging';
-import { IConnectionConfiguration } from './interfaces';
+import { IConnectionConfiguration, PuppetInstallType } from './interfaces';
+import { PathResolver } from './configuration/pathResolver';
 
 export class RubyHelper {
-  private static getDirectories(parent:string) {
-    return fs.readdirSync(parent).filter(function(file) {
-      return fs.statSync(path.join(parent, file)).isDirectory();
-    });
-  }
 
-  private static pathEnvSeparator() {
-    if (process.platform === 'win32') {
-      return ';';
-    } else {
-      return ':';
-    }
-  }
-
-  public static getRubyEnvFromPuppetAgent(
+  public static getRubyEnvFromConfiguration(
     rubyFile:string,
     connectionConfiguration: IConnectionConfiguration,
     logger: ILogger
-  ) {
-    let logPrefix: string = '[getRubyExecFromPuppetAgent] ';
+  ):{
+    command: string;
+    args: string[];
+    options: cp.SpawnOptions;
+  } {
+
     // setup defaults
     let spawn_options: cp.SpawnOptions = {};
-    spawn_options.env = process.env;
-    let result = {
-      command: 'ruby',
-      args: [rubyFile],
-      options: spawn_options
-    };
+        spawn_options.env              = process.env;
+        spawn_options.stdio            = 'pipe';
 
     switch (process.platform) {
       case 'win32':
-        result.options.stdio = 'pipe';
         break;
       default:
-        result.options.stdio = 'pipe';
-        result.options.shell = true;
+        spawn_options.shell = true;
         break;
     }
 
-    // Setup the process environment variables
-    if (result.options.env.PATH === undefined) {
-      result.options.env.PATH = '';
+    if (spawn_options.env.PATH === undefined) { spawn_options.env.PATH = ''; }
+    if (spawn_options.env.RUBYLIB === undefined) { spawn_options.env.RUBYLIB = ''; }
+
+    let command = '';
+    let logPrefix: string='';
+    switch(connectionConfiguration.puppetInstallType){
+      case PuppetInstallType.PDK:
+        logPrefix                        = '[getRubyEnvFromPDK] ';
+        spawn_options.env.DEVKIT_BASEDIR = connectionConfiguration.puppetBaseDir;
+        spawn_options.env.RUBY_DIR       = connectionConfiguration.pdkRubyDir;
+        spawn_options.env.RUBYLIB        = new Array(connectionConfiguration.pdkRubyLib, spawn_options.env.RUBYLIB).join(PathResolver.pathEnvSeparator());
+        spawn_options.env.PATH           = new Array(connectionConfiguration.pdkBinDir, connectionConfiguration.pdkRubyBinDir, spawn_options.env.PATH).join(PathResolver.pathEnvSeparator());
+        spawn_options.env.RUBYOPT        = 'rubygems';
+        spawn_options.env.GEM_HOME       = connectionConfiguration.pdkGemDir;
+        spawn_options.env.GEM_PATH       = new Array(connectionConfiguration.pdkGemVerDir, connectionConfiguration.pdkGemDir, connectionConfiguration.pdkRubyVerDir).join(PathResolver.pathEnvSeparator());
+        command                          = path.join(connectionConfiguration.pdkRubyDir, 'bin', 'ruby');
+        break;
+      case PuppetInstallType.PUPPET:
+        logPrefix                       = '[getRubyExecFromPuppetAgent] ';
+        spawn_options.env.RUBY_DIR      = connectionConfiguration.rubydir;
+        spawn_options.env.PATH          = new Array(connectionConfiguration.environmentPath, spawn_options.env.PATH).join(PathResolver.pathEnvSeparator());
+        spawn_options.env.RUBYLIB       = new Array(connectionConfiguration.rubylib, spawn_options.env.RUBYLIB).join(PathResolver.pathEnvSeparator());
+        spawn_options.env.RUBYOPT       = 'rubygems';
+        spawn_options.env.SSL_CERT_FILE = connectionConfiguration.sslCertFile;
+        spawn_options.env.SSL_CERT_DIR  = connectionConfiguration.sslCertDir;
+        command                         = 'ruby';
+        break;
     }
-    if (result.options.env.RUBYLIB === undefined) {
-      result.options.env.RUBYLIB = '';
-    }
-    result.options.env.RUBY_DIR = connectionConfiguration.rubydir;
-    result.options.env.PATH =connectionConfiguration.environmentPath + this.pathEnvSeparator() + result.options.env.PATH;
-    result.options.env.RUBYLIB = connectionConfiguration.rubylib + this.pathEnvSeparator() + result.options.env.RUBYLIB;
-    result.options.env.RUBYOPT = 'rubygems';
-    result.options.env.SSL_CERT_FILE = connectionConfiguration.sslCertFile;
-    result.options.env.SSL_CERT_DIR = connectionConfiguration.sslCertDir;
 
-    logger.debug(logPrefix + 'Using environment variable RUBY_DIR=' + result.options.env.RUBY_DIR);
-    logger.debug(logPrefix + 'Using environment variable PATH=' + result.options.env.PATH);
-    logger.debug(logPrefix + 'Using environment variable RUBYLIB=' + result.options.env.RUBYLIB);
-    logger.debug(logPrefix + 'Using environment variable RUBYOPT=' + result.options.env.RUBYOPT);
-    logger.debug(logPrefix + 'Using environment variable SSL_CERT_FILE=' + result.options.env.SSL_CERT_FILE);
-    logger.debug(logPrefix + 'Using environment variable SSL_CERT_DIR=' + result.options.env.SSL_CERT_DIR);
+    logger.debug(logPrefix + 'Using environment variable RUBY_DIR='      + spawn_options.env.RUBY_DIR);
+    logger.debug(logPrefix + 'Using environment variable PATH='          + spawn_options.env.PATH);
+    logger.debug(logPrefix + 'Using environment variable RUBYLIB='       + spawn_options.env.RUBYLIB);
+    logger.debug(logPrefix + 'Using environment variable RUBYOPT='       + spawn_options.env.RUBYOPT);
+    logger.debug(logPrefix + 'Using environment variable SSL_CERT_FILE=' + spawn_options.env.SSL_CERT_FILE);
+    logger.debug(logPrefix + 'Using environment variable SSL_CERT_DIR='  + spawn_options.env.SSL_CERT_DIR);
+    logger.debug(logPrefix + 'Using environment variable GEM_PATH='      + spawn_options.env.GEM_PATH);
+    logger.debug(logPrefix + 'Using environment variable GEM_HOME='      + spawn_options.env.GEM_HOME);
 
-    return result;
-  }
-
-  public static getRubyEnvFromPDK(rubyFile:string, connectionConfiguration: IConnectionConfiguration, logger: ILogger) {
-    let logPrefix: string = '[getRubyEnvFromPDK] ';
-    // setup defaults
-    let spawn_options: cp.SpawnOptions = {};
-    spawn_options.env = process.env;
     let result = {
-      command: 'ruby',
-      args: [rubyFile],
+      command: command,
+      args   : [rubyFile],
       options: spawn_options
     };
-    let pdkDir: string = connectionConfiguration.pdkDir;
-
-    switch (process.platform) {
-      case 'win32':
-        result.options.stdio = 'pipe';
-        break;
-      default:
-        result.options.stdio = 'pipe';
-        result.options.shell = true;
-        break;
-    }
-    // Check if this really is a PDK installation
-    if (!fs.existsSync(path.join(pdkDir, 'PDK_VERSION'))) {
-      logger.debug(logPrefix + 'Could not find a valid PDK installation at ' + pdkDir);
-      return null;
-    } else {
-      logger.debug(logPrefix + 'Found a valid PDK installation at ' + pdkDir);
-    }
-
-    // Now to detect ruby versions
-    let subdirs = this.getDirectories(path.join(pdkDir, 'private', 'ruby'));
-    if (subdirs.length === 0) {
-      return null;
-    }
-    let rubyDir = path.join(pdkDir, 'private', 'ruby', subdirs[0]);
-
-    subdirs = this.getDirectories(path.join(pdkDir, 'share', 'cache', 'ruby'));
-    if (subdirs.length === 0) {
-      return null;
-    }
-    let gemDir = path.join(pdkDir, 'share', 'cache', 'ruby', subdirs[0]);
-
-    let rubylib = path.join(pdkDir, 'lib');
-    if (process.platform === 'win32') {
-      // Translate all slashes to / style to avoid puppet/ruby issue #11930
-      rubylib = rubylib.replace(/\\/g, '/');
-      gemDir = gemDir.replace(/\\/g, '/');
-    }
-
-    // Setup the process environment variables
-    if (result.options.env.PATH === undefined) {
-      result.options.env.PATH = '';
-    }
-    if (result.options.env.RUBYLIB === undefined) {
-      result.options.env.RUBYLIB = '';
-    }
-
-    result.options.env.RUBY_DIR = rubyDir;
-    result.options.env.PATH =
-      path.join(pdkDir, 'bin') +
-      this.pathEnvSeparator() +
-      path.join(rubyDir, 'bin') +
-      this.pathEnvSeparator() +
-      result.options.env.PATH;
-    result.options.env.RUBYLIB = path.join(pdkDir, 'lib') + this.pathEnvSeparator() + result.options.env.RUBYLIB;
-    result.options.env.GEM_PATH = gemDir;
-    result.options.env.GEM_HOME = gemDir;
-    result.options.env.RUBYOPT = 'rubygems';
-
-    logger.debug(logPrefix + 'Using environment variable RUBY_DIR=' + result.options.env.RUBY_DIR);
-    logger.debug(logPrefix + 'Using environment variable PATH=' + result.options.env.PATH);
-    logger.debug(logPrefix + 'Using environment variable RUBYLIB=' + result.options.env.RUBYLIB);
-    logger.debug(logPrefix + 'Using environment variable GEM_PATH=' + result.options.env.GEM_PATH);
-    logger.debug(logPrefix + 'Using environment variable GEM_HOME=' + result.options.env.GEM_HOME);
-    logger.debug(logPrefix + 'Using environment variable RUBYOPT=' + result.options.env.RUBYOPT);
 
     return result;
+
   }
 }

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert';
+
+import * as vscode from 'vscode';
+import { ConnectionConfiguration } from '../configuration';
+import { PuppetInstallType } from '../interfaces';
+
+suite("Configuration Tests", () => {
+  var pdkBinDir = '';
+  var pdkPuppetBaseDir = '';
+  var puppetBaseDir = '';
+
+  switch(process.platform){
+    case 'win32':
+      pdkPuppetBaseDir = 'C:\\Program Files\\Puppet Labs\\DevelopmentKit';
+      pdkBinDir        = 'C:\\Program Files\\Puppet Labs\\DevelopmentKit\\bin';
+      puppetBaseDir    = 'C:\\Program Files\\Puppet Labs\\Puppet';
+      break;
+    default:
+      pdkPuppetBaseDir = '/opt/puppetlabs/pdk';
+      pdkBinDir        = '/opt/puppetlabs/pdk/bin';
+      puppetBaseDir    = '/opt/puppetlabs';
+      break;
+  }
+
+  test("correct install type", () => {
+    var config = new ConnectionConfiguration();
+    assert.equal(PuppetInstallType.PDK, config.puppetInstallType);
+  });
+
+  test("resolves puppetBaseDir as pdk with default installtype", () => {
+    var config = new ConnectionConfiguration();
+    assert.equal(config.puppetBaseDir, pdkPuppetBaseDir);
+  });
+
+  test("resolves puppetBaseDir as puppet with installtype eq puppet", () => {
+    var config = new ConnectionConfiguration();
+    config.puppetInstallType = PuppetInstallType.PUPPET;
+    assert.equal(config.puppetBaseDir, puppetBaseDir);
+  });
+
+  test("resolves pdkBinDir with installtype eq pdk", () => {
+    var config = new ConnectionConfiguration();
+    config.puppetInstallType = PuppetInstallType.PDK;
+    assert.equal(config.pdkBinDir, pdkBinDir);
+  });
+
+});

--- a/src/test/paths.test.ts
+++ b/src/test/paths.test.ts
@@ -1,0 +1,30 @@
+import * as assert from 'assert';
+
+import * as vscode from 'vscode';
+import { PathResolver } from '../configuration/pathResolver';
+
+suite("Path Resolution Tests", () => {
+
+  test("resolves programfiles", () => {
+    switch(process.platform){
+      case 'win32':
+        assert.equal('C:\\Program Files', PathResolver.getprogramFiles());
+        break;
+      default:
+        assert.equal('/opt', PathResolver.getprogramFiles());
+        break;
+    }
+  });
+  
+  test("resolves environment PATH seperator", () => {
+    switch(process.platform){
+      case 'win32':
+        assert.equal(';', PathResolver.pathEnvSeparator());
+        break;
+      default:
+        assert.equal(':', PathResolver.pathEnvSeparator());
+        break;
+    }
+  });
+
+});


### PR DESCRIPTION

This PR adds PDK as a source location for the language server.


- A new configuration point is added: `puppet.installType` which reflects either PDK or Puppet-Agent, default set to `pdk`.
- A new configuration point is added: `puppet.InstallDirectory` which can refer to either a Puppet-Agent directory or a PDK directory.
- The `puppet.puppetAgentDir` configuration point has been removed

If no configuration is set by the user, the extension will look for a PDK install in the default location. 


