### PR TITLE
(GH-343) Shallow clone process environment

### DIFF
--- a/src/rubyHelper.ts
+++ b/src/rubyHelper.ts
@@ -19,7 +19,7 @@ export class RubyHelper {
 
     // setup defaults
     let spawn_options: cp.SpawnOptions = {};
-        spawn_options.env              = process.env;
+        spawn_options.env              = this.shallowCloneObject(process.env);
         spawn_options.stdio            = 'pipe';
 
     switch (process.platform) {
@@ -76,5 +76,15 @@ export class RubyHelper {
 
     return result;
 
+  }
+
+  private static shallowCloneObject(value:Object): Object {
+    const clone: Object = {};
+    for (const propertyName in value){
+      if (value.hasOwnProperty(propertyName)){
+        clone[propertyName] = value[propertyName];
+      }
+    }
+    return clone;
   }
 }


### PR DESCRIPTION
Previously the rubyHelper would use the existing environment when building the
child process for the Language Server.  However it would also set the process
environment variables as well.  This commit adds a cloning function to instead
clone the existing process environment variables, which then stops the parent
variables being modified by accident.

Fixes #343 