### PR TITLE
(GH-278) Use a newer sane settings layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,10 +267,60 @@
       "type": "object",
       "title": "puppet",
       "properties": {
+        "puppet.editorService.debugFilePath": {
+          "type": "string",
+          "default": "",
+          "description": "The absolute filepath where the Puppet Editor Service will output the debugging log. By default no logfile is generated"
+        },
+        "puppet.editorService.featureFlags": {
+          "type": "array",
+          "default": [],
+          "description": "An array of strings of experimental features to enable in the Puppet Editor Service"
+        },
+        "puppet.editorService.loglevel": {
+          "type": "string",
+          "default": "normal",
+          "description": "Set the logging verbosity level for the Puppet Editor Service, with Debug producing the most output and Error producing the least",
+          "enum": [
+            "debug",
+            "error",
+            "normal",
+            "warning",
+            "verbose"
+          ]
+        },
+        "puppet.editorService.protocol": {
+          "type": "string",
+          "default": "stdio",
+          "description": "The protocol used to communicate with the Puppet Editor Service.  By default the local STDIO protocol is used",
+          "enum": [
+            "stdio",
+            "tcp"
+          ]
+        },
+        "puppet.editorService.tcp.address": {
+          "type": "string",
+          "description": "The IP address or hostname of the remote Puppet Editor Service to connect to, for example 'computer.domain' or '192.168.0.1'. Only applicable when the editorService.protocol is set to tcp"
+        },
+        "puppet.editorService.tcp.port": {
+          "type": "integer",
+          "description": "The TCP Port of the remote Puppet Editor Service to connect to. Only applicable when the editorService.protocol is set to tcp"
+        },
+        "puppet.editorService.timeout": {
+          "type": "integer",
+          "default": 10,
+          "description": "The timeout to connect to the Puppet Editor Service"
+        },
+        "puppet.format.enable": {
+          "type": "boolean",
+          "scope": "window",
+          "default": true,
+          "description": "Enable/disable the Puppet document formatter"
+        },
         "puppet.installType": {
           "type": "string",
           "default": "agent",
-          "description": "The Puppet Install Type",
+          "description": "The type of Puppet installation. Either the Puppet Development Kit (pdk) or the Puppet Agent (agent)",
           "enum": [
             "pdk",
             "agent"
@@ -279,58 +329,30 @@
         "puppet.puppetAgentDir": {
           "type": "string",
           "default": null,
-          "description": "The fully qualified path to the Puppet agent install directory. For example: 'C:\\Program Files\\Puppet Labs\\Puppet' or '/opt/puppetlabs/puppet'"
+          "description": "The fully qualified path to the Puppet agent install directory. For example: 'C:\\Program Files\\Puppet Labs\\Puppet' or '/opt/puppetlabs/puppet'.  If this is not set the extension will attempt to detect the installation directory"
         },
+
+
         "puppet.languageclient.protocol": {
-          "type": "string",
-          "default": "stdio",
-          "description": "protocol",
-          "enum": [
-            "stdio",
-            "tcp"
-          ]
+          "description": "**DEPRECATED** Please use puppet.editorService.protocol instead"
         },
         "puppet.languageclient.minimumUserLogLevel": {
-          "type": "string",
-          "default": "normal",
-          "description": "Set the minimum log level that the user will see on the Puppet connection logs",
-          "enum": [
-            "verbose",
-            "debug",
-            "normal",
-            "warning",
-            "error"
-          ]
+          "description": "**DEPRECATED** Please use puppet.editorService.loglevel instead"
         },
         "puppet.languageserver.address": {
-          "type": "string",
-          "default": "127.0.0.1",
-          "description": "The IP address or hostname of the Puppet Language Server to connect to"
+          "description":  "**DEPRECATED** Please use puppet.editorService.tcp.address instead"
         },
         "puppet.languageserver.port": {
-          "type": "integer",
-          "description": "The TCP Port of the Puppet Language Server to connect to"
+          "description": "**DEPRECATED** Please use puppet.editorService.tcp.port instead"
         },
         "puppet.languageserver.timeout": {
-          "type": "integer",
-          "default": 10,
-          "description": "The timeout to connect to the local Puppet Language Server"
+          "description": "**DEPRECATED** Please use puppet.editorService.timeout instead"
         },
         "puppet.languageserver.filecache.enable": {
-          "type": "boolean",
-          "default": false,
-          "description": "(Experimental) Enable a persistent file cache for Puppet objects in the Language Server"
+          "description": "**DEPRECATED** Please use puppet.editorService.featureFlags with 'filecache' instead"
         },
         "puppet.languageserver.debugFilePath": {
-          "type": "string",
-          "default": "",
-          "description": "Set the local Puppet Language Server to send debug information to a file"
-        },
-        "puppet.format.enable": {
-          "type": "boolean",
-          "scope": "window",
-          "default": true,
-          "description": "Enable/disable the Puppet formatter"
+          "description": "**DEPRECATED** Please use puppet.editorService.debugFilePath instead"
         }
       }
     },

--- a/src/PuppetLanguageClient.ts
+++ b/src/PuppetLanguageClient.ts
@@ -35,7 +35,7 @@ export class PuppetLanguageClient {
     this.statusBarItem = statusBarItem;
     this.logger = logger;
 
-    var title = `tcp lang server (host ${this.host} port ${this.port})`;
+    const title:string = 'Puppet Editor Service';
 
     this.languageServerClient = new LanguageClient(title, this.serverOptions, this.clientOptions);
     this.languageServerClient.onReady().then(

--- a/src/commands/puppetcommands.ts
+++ b/src/commands/puppetcommands.ts
@@ -9,8 +9,9 @@ import {
 import { PuppetResourceCommand } from '../commands/puppet/puppetResourceCommand';
 import { PuppetFormatDocumentProvider } from '../providers/puppetFormatDocumentProvider';
 import { PuppetStatusBar } from '../PuppetStatusBar';
+import { ISettings } from '../settings';
 
-export function setupPuppetCommands(langID:string, connManager:IConnectionManager, ctx:vscode.ExtensionContext, logger: ILogger){
+export function setupPuppetCommands(langID:string, connManager:IConnectionManager, settings:ISettings, ctx:vscode.ExtensionContext, logger: ILogger){
 
   let resourceCommand = new PuppetResourceCommand(connManager, logger);
   ctx.subscriptions.push(resourceCommand);
@@ -18,15 +19,11 @@ export function setupPuppetCommands(langID:string, connManager:IConnectionManage
     resourceCommand.run();
   }));
 
-  ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider('puppet', {
-    provideDocumentFormattingEdits: (document, options, token) => {
-      if (vscode.workspace.getConfiguration('puppet').get('format.enable')) {
-        return PuppetFormatDocumentProvider(document, options, connManager)
-      } else {
-        return []
-      }
-    }
-  }));
+  if (settings.format.enable === true) {
+    ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider('puppet', {
+      provideDocumentFormattingEdits: (document, options, token) => { return PuppetFormatDocumentProvider(document, options, connManager); }}
+    ));
+  }
 
   ctx.subscriptions.push(vscode.commands.registerCommand(PuppetCommandStrings.PuppetNodeGraphToTheSideCommandId,
     uri => showNodeGraph(uri, true))

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2,7 +2,7 @@ import net = require('net');
 import vscode = require('vscode');
 import cp = require('child_process');
 import { ILogger } from '../src/logging';
-import { IConnectionConfiguration, ConnectionStatus, ConnectionType, ProtocolType } from './interfaces'
+import { IConnectionConfiguration, ConnectionStatus, ConnectionType, ProtocolType } from './interfaces';
 import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient';
 import { RubyHelper } from './rubyHelper';
 import { PuppetStatusBar } from './PuppetStatusBar';
@@ -226,7 +226,7 @@ export class ConnectionManager implements IConnectionManager {
         var attempt = 0;
         var client = new net.Socket();
 
-        const rconnect = () => { client.connect(port, address) };
+        const rconnect = () => { client.connect(port, address); };
 
         client.connect(port, address, function() {
           logger.debug(`[Puppet Lang Server Client] tcp connected`);
@@ -291,12 +291,6 @@ export class ConnectionManager implements IConnectionManager {
 
     let serverOptions: ServerOptions;
     switch (this.connectionConfiguration.protocol) {
-      case ProtocolType.STDIO:
-      this.logger.debug(
-        `Starting language server client (stdio)`
-      );
-        serverOptions = this.STDIOServerOptions(this.languageServerProcess, this.logger);
-        break;
       case ProtocolType.TCP:
         serverOptions =  this.createTCPServerOptions(
           this.connectionConfiguration.host,
@@ -309,6 +303,13 @@ export class ConnectionManager implements IConnectionManager {
             this.connectionConfiguration.port
           })`
         );
+        break;
+      // Default is STDIO if the protocol is unknown, or STDIO
+      default:
+        this.logger.debug(
+          `Starting language server client (stdio)`
+        );
+        serverOptions = this.STDIOServerOptions(this.languageServerProcess, this.logger);
         break;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ import { Reporter } from './telemetry/telemetry';
 import { setupPuppetCommands } from './commands/puppetcommands';
 import { setupPDKCommands } from './commands/pdkcommands';
 import { PuppetStatusBar } from './PuppetStatusBar';
-import { ISettings, settingsFromWorkspace } from './settings';
+import { ISettings, legacySettings, settingsFromWorkspace } from './settings';
 
 var connManager: ConnectionManager;
 var commandsRegistered = false;
@@ -29,6 +29,14 @@ export function activate(context: vscode.ExtensionContext) {
   var logger = new OutputChannelLogger(settings);
   var statusBar = new PuppetStatusBar(langID);
   var configSettings = new ConnectionConfiguration();
+
+  // Raise a warning if we detect any legacy settings
+  const legacySettingValues: Map<string, Object> = legacySettings();
+  if (legacySettingValues.size > 0) {
+    let settingNames: string[] = [];
+    for (const [settingName, _value] of legacySettingValues) { settingNames.push(settingName); }
+    vscode.window.showWarningMessage("Deprecated Puppet settings have been detected. Please either remove them or, convert them to the correct settings names. (" + settingNames.join(", ") + ")", { modal: false});
+  }
 
   if (!fs.existsSync(configSettings.puppetBaseDir)) {
     logger.error('Could not find a valid Puppet installation at ' + configSettings.puppetBaseDir);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { Reporter } from './telemetry/telemetry';
 import { setupPuppetCommands } from './commands/puppetcommands';
 import { setupPDKCommands } from './commands/pdkcommands';
 import { PuppetStatusBar } from './PuppetStatusBar';
+import { ISettings, settingsFromWorkspace } from './settings';
 
 var connManager: ConnectionManager;
 var commandsRegistered = false;
@@ -22,8 +23,10 @@ export function activate(context: vscode.ExtensionContext) {
 
   notifyOnNewExtensionVersion(context, puppetExtensionVersion);
 
+  const settings: ISettings = settingsFromWorkspace();
+
   context.subscriptions.push(new Reporter(context));
-  var logger = new OutputChannelLogger();
+  var logger = new OutputChannelLogger(settings);
   var statusBar = new PuppetStatusBar(langID);
   var configSettings = new ConnectionConfiguration();
 
@@ -58,7 +61,7 @@ export function activate(context: vscode.ExtensionContext) {
   if (!commandsRegistered) {
     logger.debug('Configuring commands');
 
-    setupPuppetCommands(langID, connManager, context, logger);
+    setupPuppetCommands(langID, connManager, settings, context, logger);
 
     terminal = vscode.window.createTerminal('Puppet PDK');
     terminal.processId.then(pid => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,9 +17,9 @@ export enum ConnectionType {
 }
 
 export enum ProtocolType {
-  UNKNOWN,
-  STDIO,
-  TCP
+  UNKNOWN = '<unknown>',
+  STDIO = 'stdio',
+  TCP = 'tcp',
 }
 
 export interface IConnectionConfiguration {

--- a/src/logging/outputchannel.ts
+++ b/src/logging/outputchannel.ts
@@ -2,6 +2,7 @@
 
 import * as vscode from 'vscode';
 import * as logging from '../logging';
+import { ISettings } from '../settings';
 
 export class OutputChannelLogger implements logging.ILogger {
   private logChannel: vscode.OutputChannel;
@@ -9,18 +10,15 @@ export class OutputChannelLogger implements logging.ILogger {
   // Minimum log level that is shown to users on logChannel
   private minimumUserLogLevel: logging.LogLevel;
 
-  constructor() {
+  constructor(settings: ISettings) {
     this.logChannel = vscode.window.createOutputChannel('Puppet');
 
-    let config = vscode.workspace.getConfiguration('puppet');
-    let logLevelName = config['languageclient']['minimumUserLogLevel'];
-    let logLevel = this.logLevelFromString(logLevelName);
+    let logLevel = settings.editorService.loglevel;
 
     if (logLevel === undefined) {
       this.minimumUserLogLevel = logging.LogLevel.Normal;
-      this.error('Logger could not interpret ' + logLevelName + ' as a log level setting');
     } else {
-      this.minimumUserLogLevel = logLevel;
+      this.minimumUserLogLevel = this.logLevelFromString(logLevel);
     }
   }
 
@@ -51,7 +49,6 @@ export class OutputChannelLogger implements logging.ILogger {
   private logWithLevel(level: logging.LogLevel, message: string) {
     let logMessage = this.logLevelPrefixAsString(level) + new Date().toISOString() + ' ' + message;
 
-    console.log(logMessage);
     if (level >= this.minimumUserLogLevel) {
       this.logChannel.appendLine(logMessage);
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,194 @@
+'use strict';
+
+import vscode = require("vscode");
+import { ProtocolType, PuppetInstallType } from './interfaces';
+
+export interface IEditorServiceDockerSettings {
+  // Future Use
+}
+
+export interface IEditorServiceTCPSettings {
+  address?: string;
+  port?: number;
+}
+
+export interface IEditorServiceSettings {
+  debugFilePath?: string;
+  docker?: IEditorServiceDockerSettings;
+  enable?: boolean;
+  featureflags?: string[];
+  loglevel?: string;
+  protocol?: string;
+  tcp?: IEditorServiceTCPSettings;
+  timeout?: number;
+}
+
+export interface IFormatSettings {
+  enable?: boolean;
+}
+
+export interface ILintSettings {
+  // Future Use
+  enable?: boolean; // Future Use: Puppet Editor Services doesn't implement this yet.
+}
+
+export interface IPDKSettings {
+  // Future Use
+}
+
+export interface ISettings {
+  editorService?: IEditorServiceSettings;
+  format?: IFormatSettings;
+  installType?: PuppetInstallType;
+  lint?: ILintSettings;
+  pdk?: IPDKSettings;
+  puppetAgentDir?: string;
+}
+
+const workspaceSectionName = "puppet";
+
+/**
+ * Safely query the workspace configuration for a nested setting option.  If it, or any part of the setting
+ * path does not exist, return undefined
+ * @param workspaceConfig The VScode workspace configuration to query
+ * @param indexes         An array of strings defining the setting path, e.g. The setting 'a.b.c' would pass indexes of ['a','b','c']
+ */
+function getSafeWorkspaceConfig(workspaceConfig: vscode.WorkspaceConfiguration, indexes:string[] ): any {
+  if (indexes.length <= 0) { return undefined; }
+
+  let index: string = indexes.shift();
+  let result: Object = workspaceConfig[index];
+  while ((indexes.length > 0) && (result !== undefined) ) {
+    index = indexes.shift();
+    result = result[index];
+  }
+
+  // A null settings is really undefined.
+  if (result === null) { return undefined; }
+
+  return result;
+}
+
+/**
+ * Retrieves the list of "legacy" or deprecated setting names and their values
+ */
+export function legacySettings(): Map<string, Object> {
+  const workspaceConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(workspaceSectionName);
+
+  let settings: Map<string, Object> = new Map<string, Object>();
+  let value: Object = undefined;
+
+  // puppet.languageclient.minimumUserLogLevel
+  value = getSafeWorkspaceConfig(workspaceConfig, ['languageclient','minimumUserLogLevel']);
+  if (value !== undefined) { settings.set("puppet.languageclient.minimumUserLogLevel", value); }
+
+  // puppet.languageclient.protocol
+  value = getSafeWorkspaceConfig(workspaceConfig, ['languageclient','protocol']);
+  if (value !== undefined) { settings.set("puppet.languageclient.protocol", value); }
+
+  // puppet.languageserver.address
+  value = getSafeWorkspaceConfig(workspaceConfig, ['languageserver','address']);
+  if (value !== undefined) { settings.set("puppet.languageserver.address", value); }
+
+  // puppet.languageserver.debugFilePath
+  value = getSafeWorkspaceConfig(workspaceConfig, ['languageserver','debugFilePath']);
+  if (value !== undefined) { settings.set("puppet.languageserver.debugFilePath", value); }
+
+  // puppet.languageserver.filecache.enable
+  value = getSafeWorkspaceConfig(workspaceConfig, ['languageserver','filecache','enable']);
+  if (value !== undefined) { settings.set("puppet.languageserver.filecache.enable", value); }
+
+  // puppet.languageserver.port
+  value = getSafeWorkspaceConfig(workspaceConfig, ['languageserver','port']);
+  if (value !== undefined) { settings.set("puppet.languageserver.port", value); }
+
+  // puppet.languageserver.timeout
+  value = getSafeWorkspaceConfig(workspaceConfig, ['languageserver','timeout']);
+  if (value !== undefined) { settings.set("puppet.languageserver.timeout", value); }
+
+  return settings;
+}
+
+export function settingsFromWorkspace(): ISettings {
+  // Default settings
+  const defaultEditorServiceSettings: IEditorServiceSettings = {
+    enable: true,
+    featureflags: [],
+    loglevel: "normal",
+    protocol: ProtocolType.STDIO,
+    timeout: 10,
+  };
+
+  const defaultFormatSettings: IFormatSettings = {
+    enable: true,
+  };
+
+  const defaultLintSettings: ILintSettings = {
+    enable: true,
+  };
+
+  const defaultPDKSettings: IPDKSettings = {};
+
+  const workspaceConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(workspaceSectionName);
+
+  // TODO: What if the wrong type is passed through? will it blow up?
+  let settings = {
+    editorService: workspaceConfig.get<IEditorServiceSettings>("editorService", defaultEditorServiceSettings),
+    format: workspaceConfig.get<IFormatSettings>("format", defaultFormatSettings),
+    installType: workspaceConfig.get<PuppetInstallType>("installType", PuppetInstallType.PUPPET),
+    lint: workspaceConfig.get<ILintSettings>("lint", defaultLintSettings),
+    pdk: workspaceConfig.get<IPDKSettings>("pdk", defaultPDKSettings),
+    puppetAgentDir: workspaceConfig.get<string>("puppetAgentDir", undefined)
+  };
+
+  /**
+   * Legacy Workspace Settings
+   * 
+   * Retrieve deprecated settings and apply them to the settings.  This is only needed as a helper and should be 
+   * removed a version or two later, after the setting is deprecated.
+   */
+
+   // Ensure that object types needed for legacy settings exists
+  if (settings.editorService === undefined) { settings.editorService = {}; }
+  if (settings.editorService.featureflags === undefined) { settings.editorService.featureflags = []; }
+  if (settings.editorService.tcp === undefined) { settings.editorService.tcp = {}; }
+
+  // Retrieve the legacy settings
+  const oldSettings: Map<string, Object> = legacySettings();
+
+  // Translate the legacy settings into the new setting names
+  for (const [settingName, value] of oldSettings) {
+    switch (settingName) {
+
+      case "puppet.languageclient.minimumUserLogLevel": // --> puppet.editorService.loglevel
+        settings.editorService.loglevel = <string>value;
+        break;
+
+      case "puppet.languageclient.protocol": // --> puppet.editorService.protocol
+        settings.editorService.protocol = <ProtocolType>value;
+        break;
+
+      case "puppet.languageserver.address": // --> puppet.editorService.tcp.address
+        settings.editorService.tcp.address = <string>value;
+        break;
+
+      case "puppet.languageserver.debugFilePath": // --> puppet.editorService.debugFilePath
+        settings.editorService.debugFilePath = <string>value;
+        break;
+
+      case "puppet.languageserver.filecache.enable": // --> puppet.editorService.featureflags['filecache']
+        if (value === true) { settings.editorService.featureflags.push("filecache"); }
+        break;
+
+      case "puppet.languageserver.port": // --> puppet.editorService.tcp.port
+        settings.editorService.tcp.port = <number>value;
+        break;
+
+      case "puppet.languageserver.timeout": // --> puppet.editorService.timeout
+        settings.editorService.timeout = <number>value;
+        break;
+    }
+  }
+
+  return settings;
+}


### PR DESCRIPTION
This commit creates the Settings interface and static methods which can parse
a workspace settings environment.  This also includes helpers for detecting
legacy or deprecated settings and can translate to the newer format.

Fixes #278 