### PR TITLE
(GH-366) Refactor Debug Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,17 @@ The Puppet extension is able to debug the compilation of a Puppet manifest; much
 * Call stack
 * Variables, but only at the top stack frame
 * Limited interactive debug console.  For example, you can assign a variable a value, but just as in regular Puppet you can't change its value later
-* Step In, Out, Over
-
-You may be presented with a Launch Configuration on first use. Please see the [VSCode Debugging link](https://code.visualstudio.com/docs/editor/debugging) for instructions on how to set this up.
+* Step In, Out, and Over
 
 The debugging features in the extension are based on the excellent ideas in [puppet-debugger](https://www.puppet-debugger.com/) by [Corey Osman](https://github.com/nwops).
 
-Settings:
+#### Configuring the debug session
+
+To debug a simple manifest in VS Code, press `F5` and VS Code will try to debug your currently active manifest by running the equivalent of `puppet apply`. Note that by default No Operation (`--noop`) is enabled so that your local computer will not be modified.
+
+The [VSCode Debugging - Launch Configurations](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) website has instructions on how to configure the debug session with more advanced options.
+
+#### Settings
 
 `manifest` - The manifest to apply.  By default this is the currently open file in the editor
 

--- a/package.json
+++ b/package.json
@@ -365,8 +365,7 @@
       {
         "type": "Puppet",
         "label": "Puppet Debugger",
-        "program": "./out/src/debugAdapter.js",
-        "runtime": "node",
+        "adapterExecutableCommand": "extension.puppetAdapterExecutableCommand",
         "languages": [
           "puppet"
         ],
@@ -380,7 +379,7 @@
               "name": "Puppet Apply current file",
               "manifest": "^\"\\${file}\"",
               "args": [],
-              "noop": false,
+              "noop": true,
               "cwd": "^\"\\${file}\""
             }
           }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/lingua-pupuli/puppet-vscode/issues"
   },
   "engines": {
-    "vscode": "^1.15.0"
+    "vscode": "^1.24.0"
   },
   "categories": [
     "Linters",

--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -1,162 +1,153 @@
 'use strict';
 
 import fs = require('fs');
-import path = require('path');
 import net = require('net');
+import { DebugSession, TerminatedEvent } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import cp = require('child_process');
 import { NullLogger } from './logging/null';
 import { ILogger } from './logging';
-import { RubyHelper } from './rubyHelper';
-import { IConnectionConfiguration, ConnectionType, ProtocolType, PuppetInstallType } from './interfaces';
 
 // This code just marshalls the STDIN/STDOUT to a socket
 
 // Pause the stdin buffer until we're connected to the debug server
 process.stdin.pause();
 
-class DebugErrorResponse implements DebugProtocol.ErrorResponse {
-  public body: { error?: DebugProtocol.Message };
-  public request_seq: number = 1;
-  public message?: string;
-  public success: boolean = false;
-  public command: string = "initialize";
-  public seq: number = 1;
-  public type: string = "response";
+// Global variables used by the NullDebugSession
+// Yeah, I don't like globals but they work
+var globalErrorMessage: string;
+var globalErrorCode: number;
+globalErrorMessage = "An unknown error occured starting the Puppet Debugger";
+globalErrorCode = 0;
 
-  constructor(errorMessage: string) {
-    this.message = errorMessage;
+// The configuration needed to start the ruby based Debug Adapter Server
+class DebugAdapterConfiguration {
+  public rubyPath: string = undefined;
+  public rubyFile: string = undefined;
+  public envVars: Object = {};
+  public host: string = undefined;
+  public port: number = undefined;
+  public tcpTimeout: number = undefined;
+  public debugFilePath: string = undefined;
+
+  /**
+   * Takes an array of command line arguments and extracts the configuration information
+   * @param args An array of command line arguments
+   * @param logger ILogger for debug logging
+   */
+  public fromInvocationArgs(args:string[], logger:ILogger): void {
+    for (const index in args) {
+      let argText = args[index];
+
+      // Strip trailing and leading double quotes
+      if (argText.charAt(0) === '"') { argText = argText.slice(1); }
+      if (argText.charAt(argText.length - 1) === '"') { argText = argText.slice(0, -1); }
+
+      if (argText.startsWith("RUBY=")) {
+        this.rubyPath = argText.substr(5);
+      }
+      if (argText.startsWith("RUBYFILE=")) {
+        this.rubyFile = argText.substr(9);
+      }
+      if (argText.startsWith("ENV=")) {
+        const envVar: string = argText.substr(4);
+        const index: number = envVar.indexOf('=');
+        if (index !== -1) {
+          const varName: string = envVar.substr(0, index);
+          const varValue: string = envVar.substr(index + 1);
+          this.envVars[varName] = varValue;
+        }
+      }
+    }
   }
 }
 
-function sendErrorMessage(message: string) {
-  let mesageObject = new DebugErrorResponse(message);
-  let jsonMessage:string = JSON.stringify(mesageObject);
-  let payloadString = `Content-Length: ${jsonMessage.length}\r\n\r\n${jsonMessage}`;
-
-  process.stdout.write(payloadString);
-}
-
-class DebugConfiguration implements IConnectionConfiguration {
-  protocol: ProtocolType;
-  puppetBaseDir: string;
-  languageServerPath: string;
-  rubydir: string;
-  rubylib: string;
-  environmentPath: string;
-  sslCertFile: string;
-  sslCertDir: string;
-  languageServerCommandLine: string[];
-  public type: ConnectionType = ConnectionType.Local ;
-  public host: string = "127.0.0.1";
-  public port: number = 8082;
-  public timeout: number = 10;
-  public enableFileCache: boolean;// tslint:disable-line:semicolon
-  public debugFilePath: string; // tslint:disable-line:semicolon
-
-  puppetInstallType:PuppetInstallType; 
-  pdkBinDir:string;
-  pdkRubyLib:string;
-  pdkRubyVerDir:string;
-  pdkGemDir:string;
-  pdkRubyDir:string;
-  pdkRubyBinDir:string;
-  pdkGemVerDir:string; 
-
-  constructor() {
-    this.type = ConnectionType.Local;
-    this.protocol = ProtocolType.TCP;
-    this.host = '127.0.0.1';
-    this.port = 8082;
-    this.timeout = 10;
-    
-    this.puppetBaseDir = '';
-    this.languageServerPath = '';
-    this.rubydir ='';
-    this.rubylib ='';
-    this.environmentPath ='';
-    this.sslCertFile ='';
-    this.sslCertDir ='';
-    this.languageServerCommandLine =[''];
-    this.enableFileCache = false;
-    this.debugFilePath = '';
-  }
-}
-
-function startDebuggingProxy(config:DebugConfiguration, logger:ILogger, exitOnClose:boolean = false) {
+function startDebuggingProxy(config: DebugAdapterConfiguration, logger:ILogger, exitOnClose:boolean = false): net.Socket {
   // Establish connection before setting up the session
   logger.debug("Connecting to " + config.host + ":" + config.port);
 
-  let isConnected = false;
-  let debugServiceSocket = net.connect(config.port, config.host);
+  let debugServiceSocket: net.Socket = net.connect(config.port, config.host);
 
   // Write any errors to the log file
   debugServiceSocket.on('error', (e) => {
-      logger.error("Socket ERROR: " + e);
-      debugServiceSocket.destroy();
-    });
+    logger.error("Socket ERROR: " + e);
+    debugServiceSocket.destroy();
+  });
 
   // Route any output from the socket through stdout
   debugServiceSocket.on('data', (data: Buffer) => process.stdout.write(data));
 
   // Wait for the connection to complete
   debugServiceSocket.on('connect', () => {
-      isConnected = true;
-      logger.debug("Connected to Debug Server");
+    logger.debug("Connected to Debug Server");
 
-      // When data comes on stdin, route it through the socket
-      process.stdin.on('data',(data: Buffer) => debugServiceSocket.write(data));
+    // When data comes on stdin, route it through the socket
+    process.stdin.on('data',(data: Buffer) => debugServiceSocket.write(data));
 
-      // Resume the stdin stream
-      process.stdin.resume();
-    });
+    // Resume the stdin stream
+    process.stdin.resume();
+  });
 
   // When the socket closes, end the session
   debugServiceSocket.on('close',() => {
     logger.debug("Socket closed, shutting down.");
     debugServiceSocket.destroy();
-    isConnected = false;
     if (exitOnClose) { process.exit(0); }
   });
+
+  return debugServiceSocket;
 }
 
-function startDebugServerProcess(cmd : string, args : Array<string>, config:DebugConfiguration, logger:ILogger, options : cp.SpawnOptions) {
-  if ((config.host === undefined) || (config.host === '')) {
-    args.push('--ip=127.0.0.1');
-  } else {
-    args.push('--ip=' + config.host);
+function shallowCloneObject(value:Object): Object {
+  const clone: Object = {};
+  for (const propertyName in value){
+    if (value.hasOwnProperty(propertyName)){
+      clone[propertyName] = value[propertyName];
+    }
   }
+  return clone;
+}
+
+function startDebugServerProcess(config: DebugAdapterConfiguration, logger:ILogger) {
+  let args = [
+    config.rubyFile,
+  ];
+
+  // Construct the Debug Server arguments.  Host and port must be set
+  if ((config.host === undefined) || (config.host === '')) { config.host = "127.0.0.1"; }
+  if ((config.port === undefined) || (config.port <= 0)) { config.port = 8082; }
+  args.push('--ip=' + config.host);
   args.push('--port=' + config.port);
-  args.push('--timeout=' + config.timeout);
+  if ((config.tcpTimeout !== undefined) && (config.tcpTimeout >= 0)) {
+    args.push('--timeout=' + config.tcpTimeout);
+  }
   if ((config.debugFilePath !== undefined) && (config.debugFilePath !== '')) {
     args.push('--debug=' + config.debugFilePath);
   }
+  // Construct the child process options
+  let spawn_options: cp.SpawnOptions = {};
+  spawn_options.env = shallowCloneObject(process.env);
+  spawn_options.stdio = 'pipe';
+  if (process.platform !== 'win32') { spawn_options.shell = true; }
+  // Construct child process environment variables
+  Object.keys(config.envVars).forEach(function (key) { 
+    spawn_options.env[key] = config.envVars[key];
+  });
 
-  logger.debug("Starting the debug server with " + cmd + " " + args.join(" "));
-  var proc = cp.spawn(cmd, args, options);
+  logger.debug("Starting the debug server with " + config.rubyPath + " " + args.join(" "));
+  var proc = cp.spawn(config.rubyPath, args, spawn_options);
   logger.debug('Debug server PID:' + proc.pid);
 
   return proc;
 }
 
-function startDebugServer(config:DebugConfiguration, debugLogger: ILogger) {
-  let localServer = null;
-
-  let rubyfile = path.join(__dirname,'..','..','vendor', 'languageserver', 'puppet-debugserver');
-  if (!fs.existsSync(rubyfile)) {
-    sendErrorMessage("Unable to find the Debug Server at " + rubyfile);
-    process.exit(255);
+function startDebugServer(config: DebugAdapterConfiguration, debugLogger: ILogger): cp.ChildProcess {
+  if (!fs.existsSync(config.rubyFile)) {
+    globalErrorMessage = "Unable to find the Puppet Debug Server at " + config.rubyFile;
+    return undefined;
   }
 
-  // TODO use argv to pass in stuff?
-  localServer = RubyHelper.getRubyEnvFromConfiguration(rubyfile, config, debugLogger);
-
-  if (!fs.existsSync(config.puppetBaseDir)) {
-    sendErrorMessage("Unable to find a valid ruby environment");
-    process.exit(255);
-  }
-
-  var debugServerProc = startDebugServerProcess(localServer.command, localServer.args, config, debugLogger, localServer.options);
+  var debugServerProc = startDebugServerProcess(config, debugLogger);
 
   let debugSessionRunning = false;
   debugServerProc.stdout.on('data', (data) => {
@@ -172,8 +163,10 @@ function startDebugServer(config:DebugConfiguration, debugLogger: ILogger) {
   return debugServerProc;
 }
 
-function startDebugging(config:DebugConfiguration, debugLogger:ILogger) {
-  var debugServerProc = startDebugServer(config, debugLogger);
+function startDebugging(config:DebugAdapterConfiguration, debugLogger:ILogger): any {
+  let debugServerProc: cp.ChildProcess = startDebugServer(config, debugLogger);
+
+  if (debugServerProc === undefined) { return undefined; }
 
   debugServerProc.on('close', (exitCode) => {
     debugLogger.debug("Debug server terminated with exit code: " + exitCode);
@@ -202,6 +195,31 @@ function startDebugging(config:DebugConfiguration, debugLogger:ILogger) {
     debugServerProc.kill();
     process.exit(0);
   });
+
+  return debugServerProc;
+}
+
+/**
+ * This is a debug adapter which runs over STDIN/STDOUT.  It's only purpose is to emit
+ * an error message and exit cleanly, so VS Code doesn't complain.
+ */
+export class NullDebugSession extends DebugSession {
+  public constructor() {
+    super();
+
+    this.on('end', () => {
+      this.sendEvent(new TerminatedEvent());
+    });
+  }
+
+  protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
+    response.body = response.body || {};
+
+    // We can never initialize properly so report an error
+    this.sendErrorResponse(response, globalErrorCode, globalErrorMessage);
+    // We need to terminate correctly otherwise VS Code gets all confused
+    this.sendEvent(new TerminatedEvent());
+  }
 }
 
 // TODO Do we need a logger? should it be optional?
@@ -211,12 +229,20 @@ function startDebugging(config:DebugConfiguration, debugLogger:ILogger) {
 // TODO Until we figure out the logging, just use the null logger
 let debugLogger = new NullLogger();
 
-debugLogger.normal("args = " + process.argv);
+const config = new DebugAdapterConfiguration();
+config.fromInvocationArgs(process.argv, debugLogger);
 
-let config = new DebugConfiguration();
+debugLogger.debug("DebugAdapterConfiguration is " + JSON.stringify(config));
 
+let debugee: Object = undefined;
 // Launch command
-startDebugging(config, debugLogger);
-
+debugee = startDebugging(config, debugLogger);
 // Attach command
-// startDebuggingProxy(config, debugLogger, true);
+// debugee = startDebuggingProxy(config, debugLogger, true);
+
+if (debugee === undefined) {
+  // For some reason, all hell has broken loose and we couldn't start the ruby based debug adapater.
+  // Now we need to emulate a debugAdpater which does nothing but report errors
+  debugLogger.debug("Couldn't start a connection to the debug adapter so just start a null debug adapter: " + globalErrorMessage);
+  NullDebugSession.run(NullDebugSession);
+}

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -1,0 +1,5 @@
+import vscode = require("vscode");
+
+export interface IFeature extends vscode.Disposable {
+    dispose();
+}

--- a/src/feature/DebugConfigurationFeature.ts
+++ b/src/feature/DebugConfigurationFeature.ts
@@ -1,0 +1,32 @@
+'use strict';
+
+import * as vscode from "vscode";
+import { IFeature } from "../feature";
+import { ILogger } from "../logging";
+
+export class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+  private logger: ILogger;
+  private context: vscode.ExtensionContext;
+
+  constructor(logger: ILogger, context: vscode.ExtensionContext) {
+    this.logger = logger;
+    this.context = context;
+  }
+
+  public provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration[]> {
+    return undefined;
+  }
+
+  public resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+    return debugConfiguration;
+  }
+}
+
+export class DebugConfigurationFeature implements IFeature {
+  constructor(logger: ILogger, context: vscode.ExtensionContext) {
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('Puppet', new DebugConfigurationProvider(logger, context)));
+    logger.debug("Registered DebugConfigurationProvider")
+  }
+
+  public dispose(): any { return undefined; }
+}

--- a/src/feature/DebugConfigurationFeature.ts
+++ b/src/feature/DebugConfigurationFeature.ts
@@ -1,31 +1,96 @@
 'use strict';
 
 import * as vscode from "vscode";
+import * as path from 'path';
+
 import { IFeature } from "../feature";
 import { ILogger } from "../logging";
+import { IConnectionConfiguration } from '../interfaces';
+import { ConnectionConfiguration } from "../configuration";
+import { RubyHelper } from "../rubyHelper";
+
+const PuppetAdapterExecutableCommandId = 'extension.puppetAdapterExecutableCommand';
 
 export class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+  private debugType: string;
   private logger: ILogger;
   private context: vscode.ExtensionContext;
 
-  constructor(logger: ILogger, context: vscode.ExtensionContext) {
+  constructor(debugType:string, logger: ILogger, context: vscode.ExtensionContext) {
+    this.debugType = debugType;
     this.logger = logger;
     this.context = context;
   }
 
-  public provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration[]> {
-    return undefined;
+  public provideDebugConfigurations(
+    folder: vscode.WorkspaceFolder | undefined,
+    token?: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.DebugConfiguration[]> {
+    return [ this.createLaunchConfigFromContext(folder) ];
   }
 
-  public resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+  public resolveDebugConfiguration(
+    folder: vscode.WorkspaceFolder | undefined,
+    debugConfiguration: vscode.DebugConfiguration,
+    token?: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.DebugConfiguration> {
     return debugConfiguration;
+  }
+
+  public puppetAdapterExecutableCommand(context: vscode.ExtensionContext) {
+    const config: IConnectionConfiguration = new ConnectionConfiguration();
+    const rubyConfig = RubyHelper.getRubyEnvFromConfiguration('', config, this.logger);
+
+    const debugAdapterPath = path.join(this.context.extensionPath, 'out', 'debugAdapter.js');
+    const debugServerPath = path.join(__dirname,'..','..','vendor', 'languageserver', 'puppet-debugserver');
+    let args = [];
+
+    args.push(debugAdapterPath);
+    // Add path the ruby executable
+    args.push(`\"RUBY=${rubyConfig.command}\"`);
+    // Add path to the Debug Server file
+    args.push(`\"RUBYFILE=${debugServerPath}\"`);
+    // // Add additional environment variables
+    const currentEnv = process.env;
+    for (const key in rubyConfig.options.env) {
+      const value = rubyConfig.options.env[key];
+      if (!currentEnv[key] || (currentEnv[key] !== value)) {
+        args.push(`\"ENV=${key}=${value}\"`);
+      }
+    }
+    // TODO: Add additional command line args e.g. --debuglogfie
+
+    return {
+      command: 'node',
+      args: args
+    };
+  }
+
+  private createLaunchConfigFromContext(folder: vscode.WorkspaceFolder | undefined): vscode.DebugConfiguration {
+    let config = {
+      type: this.debugType,
+      request: 'launch',
+      name: 'Puppet Apply current file',
+      manifest: "${file}",
+      args: [],
+      noop: true,
+      cwd: "${file}",
+    };
+
+    return config;
   }
 }
 
 export class DebugConfigurationFeature implements IFeature {
+  private debugType: string = 'Puppet';
+  private provider: DebugConfigurationProvider;
+
   constructor(logger: ILogger, context: vscode.ExtensionContext) {
-    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('Puppet', new DebugConfigurationProvider(logger, context)));
-    logger.debug("Registered DebugConfigurationProvider")
+    this.provider = new DebugConfigurationProvider(this.debugType, logger, context);
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(this.debugType, this.provider));
+    logger.debug("Registered DebugConfigurationProvider");
+    context.subscriptions.push(vscode.commands.registerCommand(PuppetAdapterExecutableCommandId, () => this.provider.puppetAdapterExecutableCommand(context)));
+    logger.debug("Registered " + PuppetAdapterExecutableCommandId + " command");
   }
 
   public dispose(): any { return undefined; }


### PR DESCRIPTION
This commit adds an implementation of a DebugConfigurationProvider;

* The adapterExecutableCommand settings is created, and a command registered
  which will return the command and arguments to start the Debug Adapter.  In
  this case the arguments will include the ruby environment information

* The provideDebugConfigurations method just returns the same debug
  configuration  as in package.json

* Modified the DebugAdapater.ts file to use the newly injected ruby information.
  This means the debug adapter no longer needs to share the code from the
  extension as itself.

* However an issue was found in the DebugAdapter, if it exited without sending
  the appropriate terminate method, VS Code would get in a weird state which
  required it to be reloaded to start debugging again.  To stop this, if the
  ruby based adapter is not spawned, a Null Debug Adapter will be started on
  STDIO which throws and error and terminates gracefully, thus VS Code does not
  get confused.

* Updated the default debug configuration to have noop = true by default

---

- [ ] Update README
- [ ] Consider name change