### PR TITLE
(GH-315) Deprecate the puppetAgentDir setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -317,6 +317,11 @@
           "default": true,
           "description": "Enable/disable the Puppet document formatter"
         },
+        "puppet.installDirectory": {
+          "type": "string",
+          "default": null,
+          "description": "The fully qualified path to the Puppet install directory. This can be a PDK or Puppet Agent installation. For example: 'C:\\Program Files\\Puppet Labs\\Puppet' or '/opt/puppetlabs/puppet'. If this is not set the extension will attempt to detect the installation directory"
+        },
         "puppet.installType": {
           "type": "string",
           "default": "agent",
@@ -325,11 +330,6 @@
             "pdk",
             "agent"
           ]
-        },
-        "puppet.puppetAgentDir": {
-          "type": "string",
-          "default": null,
-          "description": "The fully qualified path to the Puppet agent install directory. For example: 'C:\\Program Files\\Puppet Labs\\Puppet' or '/opt/puppetlabs/puppet'.  If this is not set the extension will attempt to detect the installation directory"
         },
 
 
@@ -353,6 +353,9 @@
         },
         "puppet.languageserver.debugFilePath": {
           "description": "**DEPRECATED** Please use puppet.editorService.debugFilePath instead"
+        },
+        "puppet.puppetAgentDir": {
+          "description": "**DEPRECATED** Please use puppet.installDirectory instead"
         }
       }
     },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -36,8 +36,8 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
   }
 
   get puppetBaseDir(): string {
-    if ( (this.settings.puppetAgentDir !== null) && (this.settings.puppetAgentDir !== undefined) && (this.settings.puppetAgentDir.trim() !== "") ) {
-      return this.settings.puppetAgentDir;
+    if ( (this.settings.installDirectory !== null) && (this.settings.installDirectory !== undefined) && (this.settings.installDirectory.trim() !== "") ) {
+      return this.settings.installDirectory;
     }
 
     let programFiles = PathResolver.getprogramFiles();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,10 +39,10 @@ export interface IPDKSettings {
 export interface ISettings {
   editorService?: IEditorServiceSettings;
   format?: IFormatSettings;
+  installDirectory?: string;
   installType?: PuppetInstallType;
   lint?: ILintSettings;
   pdk?: IPDKSettings;
-  puppetAgentDir?: string;
 }
 
 const workspaceSectionName = "puppet";
@@ -106,6 +106,10 @@ export function legacySettings(): Map<string, Object> {
   value = getSafeWorkspaceConfig(workspaceConfig, ['languageserver','timeout']);
   if (value !== undefined) { settings.set("puppet.languageserver.timeout", value); }
 
+  // puppet.puppetAgentDir
+  value = getSafeWorkspaceConfig(workspaceConfig, ['puppetAgentDir']);
+  if (value !== undefined) { settings.set("puppet.puppetAgentDir", value); }
+
   return settings;
 }
 
@@ -135,10 +139,10 @@ export function settingsFromWorkspace(): ISettings {
   let settings = {
     editorService: workspaceConfig.get<IEditorServiceSettings>("editorService", defaultEditorServiceSettings),
     format: workspaceConfig.get<IFormatSettings>("format", defaultFormatSettings),
+    installDirectory: workspaceConfig.get<string>("installDirectory", undefined),
     installType: workspaceConfig.get<PuppetInstallType>("installType", PuppetInstallType.PUPPET),
     lint: workspaceConfig.get<ILintSettings>("lint", defaultLintSettings),
-    pdk: workspaceConfig.get<IPDKSettings>("pdk", defaultPDKSettings),
-    puppetAgentDir: workspaceConfig.get<string>("puppetAgentDir", undefined)
+    pdk: workspaceConfig.get<IPDKSettings>("pdk", defaultPDKSettings)
   };
 
   /**
@@ -187,7 +191,11 @@ export function settingsFromWorkspace(): ISettings {
       case "puppet.languageserver.timeout": // --> puppet.editorService.timeout
         settings.editorService.timeout = <number>value;
         break;
-    }
+
+      case "puppet.puppetAgentDir": // --> puppet.installDirectory
+        settings.installDirectory = <string>value;
+        break;
+      }
   }
 
   return settings;


### PR DESCRIPTION
This commit deprecates the puppetAgentDir setting and instead uses the
installDirectory setting name.  This will consolidate both PDK and Puppet
Agent directories, and make way for adding PDK support.

This builds on #361 