### PR TITLE
(maint) Fix node graph generation

### DIFF
--- a/src/feature/NodeGraphFeature.ts
+++ b/src/feature/NodeGraphFeature.ts
@@ -55,9 +55,10 @@ class NodeGraphContentProvider implements vscode.TextDocumentContentProvider {
             node [ shape="box" penwidth="2" color="#e0e0e0" style="rounded,filled" fontname="Courier New" fillcolor=black, fontcolor="white"]
             edge [ style="bold" color="#f0f0f0" penwith="2" ]
 
-            label = ""`
+            label = ""`;
 
             var graphContent = compileResult.dotContent;
+            if (graphContent === undefined) { graphContent = ''; }
             // vis.jz sees backslashes as escape characters, however they are not in the DOT language.  Instead
             // we should escape any backslash coming from a valid DOT file in preparation to be rendered
             graphContent = graphContent.replace(/\\/g,"\\\\");
@@ -66,7 +67,7 @@ class NodeGraphContentProvider implements vscode.TextDocumentContentProvider {
             svgContent = viz(graphContent,"svg");
           }
 
-          var errorContent = `<div style='font-size: 1.5em'>${compileResult.error}</div>`
+          var errorContent = `<div style='font-size: 1.5em'>${compileResult.error}</div>`;
           if ((compileResult.error === undefined) || (compileResult.error === null)) { errorContent = ''; }
 
           if (reporter) {


### PR DESCRIPTION
Previously the langauge server would optionally return a property called
dotContent when an error occured during Node Graph generation.  However the
language client always assumed that dotContent was returned.  This commit
updates the client to use an empty string if dotContent is not returned by the
server.
