### PR TITLE
(maint) Update configuration title

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     },
     "configuration": {
       "type": "object",
-      "title": "puppet",
+      "title": "Puppet",
       "properties": {
         "puppet.editorService.debugFilePath": {
           "type": "string",


### PR DESCRIPTION
Previously the configuration title didn't really matter but now that VSCode has
a visual settings editor, the name 'puppet' is a typo.  This commit changes the
title for the extensions settings to 'Puppet'.
