### PR TITLE
(GH-399) Update status bar loading UI

### DIFF
--- a/src/PuppetStatusBar.ts
+++ b/src/PuppetStatusBar.ts
@@ -25,22 +25,43 @@ export class PuppetStatusBar {
     });
   }
 
-  public setConnectionStatus(statusText: string, status: ConnectionStatus): void {
+  public setConnectionStatus(statusText: string, status: ConnectionStatus, toolTip: string): void {
     this.logger.debug(`Setting status bar to ${statusText}`);
-    // Set color and icon for 'Running' by default
-    var statusIconText = '$(terminal) ';
-    var statusColor = '#affc74';
+    // Icons are from https://octicons.github.com/
+    var statusIconText: string;
+    var statusColor: string;
 
-    if (status === ConnectionStatus.Starting) {
-      statusIconText = '$(sync) ';
-      statusColor = '#f3fc74';
-    } else if (status === ConnectionStatus.Failed) {
-      statusIconText = '$(alert) ';
-      statusColor = '#fcc174';
+    switch (status) {
+      case ConnectionStatus.RunningLoaded:
+        statusIconText = '$(terminal) ';
+        statusColor = '#affc74';
+        break;
+      case ConnectionStatus.RunningLoading:
+        // When the editor service is starting, it's functional but it may be missing
+        // type/class/function/fact info.  But language only features like format document
+        // or document symbol, are available
+        statusIconText = '$(sync~spin) ';
+        statusColor = '#affc74';
+        break;
+      case ConnectionStatus.Failed:
+        statusIconText = '$(alert) ';
+        statusColor = '#fcc174';
+        break;
+      default:
+        // ConnectionStatus.NotStarted
+        // ConnectionStatus.Starting
+        // ConnectionStatus.Stopping
+        statusIconText = '$(gear) ';
+        statusColor = '#f3fc74';
+        break;
     }
 
+    statusIconText = (statusIconText + statusText).trim();
     this.statusBarItem.color = statusColor;
-    this.statusBarItem.text = statusIconText + statusText;
+    // Using a conditional here because resetting a $(sync~spin) will cause the animation to restart. Instead
+    // Only change the status bar text if it has actually changed.
+    if (this.statusBarItem.text !== statusIconText) { this.statusBarItem.text = statusIconText; }
+    this.statusBarItem.tooltip = toolTip; // TODO: killme (new Date()).getUTCDate().toString() + "\nNewline\nWee!";
   }
 
   public static showConnectionMenu() {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -69,7 +69,7 @@ export class ConnectionManager implements IConnectionManager {
     // Setup the configuration
     this.connectionConfiguration = connectionConfig;
 
-    this.setConnectionStatus('Starting Puppet...', ConnectionStatus.Starting);
+    this.setConnectionStatus('Starting Puppet...', ConnectionStatus.Starting, '');
 
     if (this.connectionConfiguration.type === ConnectionType.Local) {
       this.createLanguageServerProcess(
@@ -246,7 +246,8 @@ export class ConnectionManager implements IConnectionManager {
             logger.error(`[Puppet Lang Server Client] ` + `Could not start language client: ${err.message}`);
             connectionManager.setConnectionStatus(
               `Could not start language client: ${err.message}`,
-              ConnectionStatus.Failed
+              ConnectionStatus.Failed,
+              ''
             );
 
             vscode.window.showErrorMessage(
@@ -346,12 +347,12 @@ export class ConnectionManager implements IConnectionManager {
     this.start(connectionConfig);
   }
 
-  private setConnectionStatus(statusText: string, status: ConnectionStatus): void {
+  private setConnectionStatus(statusText: string, status: ConnectionStatus, toolTip: string): void {
     this.connectionStatus = status;
-    this.statusBarItem.setConnectionStatus(statusText, status);
+    this.statusBarItem.setConnectionStatus(statusText, status, toolTip);
   }
 
   private setSessionFailure(message: string, ...additionalMessages: string[]) {
-    this.setConnectionStatus('Starting Error', ConnectionStatus.Failed);
+    this.setConnectionStatus('Starting Error', ConnectionStatus.Failed, '');
   }
 }

--- a/src/feature/FormatDocumentFeature.ts
+++ b/src/feature/FormatDocumentFeature.ts
@@ -21,7 +21,7 @@ class FormatDocumentProvider {
   }
 
   public async formatTextEdits(document: vscode.TextDocument, options: vscode.FormattingOptions): Promise<vscode.TextEdit[]> {
-    if (this.connectionManager.status !== ConnectionStatus.Running) {
+    if ((this.connectionManager.status !== ConnectionStatus.RunningLoaded) && (this.connectionManager.status !== ConnectionStatus.RunningLoading)) {
       vscode.window.showInformationMessage("Please wait and try again. The Puppet extension is still loading...");
       return [];
     }

--- a/src/feature/NodeGraphFeature.ts
+++ b/src/feature/NodeGraphFeature.ts
@@ -32,7 +32,7 @@ class NodeGraphContentProvider implements vscode.TextDocumentContentProvider {
         source: sourceUri.toString()
       };
 
-      if ((this.connectionManager.status !== ConnectionStatus.Running) && (this.connectionManager.status !== ConnectionStatus.Starting)) {
+      if ((this.connectionManager.status !== ConnectionStatus.RunningLoaded) && (this.connectionManager.status !== ConnectionStatus.RunningLoading)) {
         if (this.shownLanguageServerNotAvailable) {
           vscode.window.showInformationMessage("The Puppet Node Graph Preview is not available as the Editor Service is not ready");
           this.shownLanguageServerNotAvailable = true;

--- a/src/feature/PuppetResourceFeature.ts
+++ b/src/feature/PuppetResourceFeature.ts
@@ -26,7 +26,7 @@ export class PuppetResourceFeature implements IFeature {
   public run() {
     var thisCommand = this;
 
-    if (thisCommand._connectionManager.status !== ConnectionStatus.Running) {
+    if (thisCommand._connectionManager.status !== ConnectionStatus.RunningLoaded) {
       vscode.window.showInformationMessage('Puppet Resource is not available as the Language Server is not ready');
       return;
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,7 +5,8 @@
 export enum ConnectionStatus {
   NotStarted,
   Starting,
-  Running,
+  RunningLoading,
+  RunningLoaded,
   Stopping,
   Failed
 }


### PR DESCRIPTION
Previously the UI when puppet was loading implied that the extension wasn't
running, however this isn't true. This commit changes the loading and
connection status so that we know when the Language Server is running, but
partially loaded vs fully loaded.

Fixes #399