### PR TITLE
(maint) Convert FormatDocumentProvider to async function

### DIFF
--- a/src/feature/FormatDocumentFeature.ts
+++ b/src/feature/FormatDocumentFeature.ts
@@ -16,32 +16,27 @@ class RequestParams implements messages.PuppetFixDiagnosticErrorsRequestParams {
 class FormatDocumentProvider {
   private connectionManager: IConnectionManager = undefined;
 
-  constructor(connectionManager:IConnectionManager) {
+  constructor(connectionManager: IConnectionManager) {
     this.connectionManager = connectionManager;
   }
 
-  public formatTextEdits(document: vscode.TextDocument, options:vscode.FormattingOptions) : Thenable<vscode.TextEdit[]> {
-    if (this.connectionManager.status !== ConnectionStatus.Running ) {
+  public async formatTextEdits(document: vscode.TextDocument, options: vscode.FormattingOptions): Promise<vscode.TextEdit[]> {
+    if (this.connectionManager.status !== ConnectionStatus.Running) {
       vscode.window.showInformationMessage("Please wait and try again. The Puppet extension is still loading...");
-      return new Promise((resolve) => { resolve([]); });
+      return [];
     }
-  
+
     let requestParams = new RequestParams;
     requestParams.documentUri = document.uri.toString(false);
     requestParams.alwaysReturnContent = false;
-  
-    return this.connectionManager.languageClient
-      .sendRequest(messages.PuppetFixDiagnosticErrorsRequest.type, requestParams)
-      .then(
-        (result) => {
-          result = result as messages.PuppetFixDiagnosticErrorsResponse;
-          if (result.fixesApplied > 0 && result.newContent != null) {
-            return [vscode.TextEdit.replace(new vscode.Range(0,0, document.lineCount,0), result.newContent)]
-          } else {
-            return []
-          }
-        }
-      );
+
+    const result = await this.connectionManager
+                             .languageClient
+                             .sendRequest(messages.PuppetFixDiagnosticErrorsRequest.type, requestParams) as messages.PuppetFixDiagnosticErrorsResponse;
+    if (result.fixesApplied > 0 && result.newContent !== undefined) {
+      return [vscode.TextEdit.replace(new vscode.Range(0, 0, document.lineCount, 0), result.newContent)];
+    }
+    return [];
   }
 }
 
@@ -60,7 +55,8 @@ export class FormatDocumentFeature implements IFeature {
     if (settings.format.enable === true) {
       logger.debug("Registered Format Document provider");
       context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(langID, {
-        provideDocumentFormattingEdits: (document, options, token) => { return this.provider.formatTextEdits(document, options); }}
+        provideDocumentFormattingEdits: (document, options, token) => { return this.provider.formatTextEdits(document, options); }
+      }
       ));
     } else {
       logger.debug("Format Document provider has not been registered");


### PR DESCRIPTION
Previously the FormatDocumentProvider was a Thenable style function however this
made the code a little complex.  This commit converts the function to async
style.  This commit also cleans up some minor code formatting to make the flow
more obvious.