### PR TITLE
(GH-334) Update vscode-extension-telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -444,7 +444,7 @@
   },
   "dependencies": {
     "vscode-languageclient": "5.1.0",
-    "vscode-extension-telemetry": "^0.0.15",
+    "vscode-extension-telemetry": "0.0.22",
     "viz.js": "~1.7.0",
     "vscode-debugprotocol": "^1.19.0",
     "vscode-debugadapter": "^1.19.0"


### PR DESCRIPTION
This commit pins the vscode-extension-telemetry package to 0.0.22