### PR TITLE
(GH-405) Update README and links into the README

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -29,5 +29,5 @@ PDK Version (if applicable):
 ### Output Log
 
 <!-- 
-For information how to capture verbose logs, look [here](https://github.com/lingua-pupuli/puppet-vscode/tree/master/client#2-capture-verbose-logs-and-send-them-to-us)
+For information how to capture verbose logs, look [here](https://github.com/lingua-pupuli/puppet-vscode#2-capture-verbose-logs-and-send-them-to-us)
 -->

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ If you're having an issue with crashing or other erratic behavior, add the follo
 line to your User Settings in Visual Studio Code:
 
 ```json
-    "puppet.languageserver.debugFilePath": "C:\\Some\\file\\path.txt"
+    "puppet.editorService.debugFilePath": "C:\\Some\\file\\path.txt"
 ```
 
 Restart Visual Studio Code and try to reproduce the problem, then examine the log. If the issue persists please open an issue.


### PR DESCRIPTION
Previously the README prompted users to use a deprecated Puppet setting.  This
commit changes the example in the README to use the new name of the same
setting.  This commit also updates the link in the Bug Report to the correct
location in the README.

Fixes #405 