### PR TITLE
Add a node snippet

### DIFF
--- a/snippets/keywords.snippets.json
+++ b/snippets/keywords.snippets.json
@@ -32,5 +32,14 @@
       "}"
     ],
     "description": "Conditional case statement"
-  }
+  },
+  "node": {
+		"prefix": "node",
+		"body": [
+			"node '${1:certname}' {",
+			"\t$0",
+			"}"
+		],
+		"description": "Node definition in your main manifest"
+	}
 }


### PR DESCRIPTION
The snippet allow the definition of a node in the main manifest in an
easy fashion. You first define the hostname of the host, and the snippet
ends in the node block.
As we do not use puppet enterprise, nor the enc of foreman (we like to define everything in git), this snippet is very useful to me, and I believe it could help others. It's pretty straigtforward.
