### PR TITLE
(maint) Add uneeded files to vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,6 @@ logs/**
 sessions/**
 gulpfile.js
 docs
+.github
+.travis.yml
+appveyor.yml


### PR DESCRIPTION
This adds CI files and github templates to the vscodeignore file.