### PR TITLE
(GH-375) Implement Docker connection handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
     - [PDK Validate](#pdk-validate)
     - [PDK Test Unit](#pdk-test-unit)
   - [Debugging Puppet manifests](#debugging-puppet-manifests)
+  - [Docker Language Server Support](#docker-language-server-support)
 - [Installing the Extension](#installing-the-extension)
 - [Configuration](#configuration)
 - [Experience a Problem?](#experience-a-problem)
@@ -69,6 +70,7 @@ This extension provides full Puppet Language support for [Visual Studio Code](ht
 - Node graph preview
 - Puppet Development Kit integration
 - (Experimental) Local debugging of Puppet manifests
+- (Experimental) Docker Language Server support
 
 **It is currently in technical preview, so that we can gather bug reports and find out what new features to add.**
 
@@ -274,6 +276,23 @@ The [VSCode Debugging - Launch Configurations](https://code.visualstudio.com/doc
 - `noop` - Whether the `puppet apply` sets No Operation (Noop) mode.  By default, this is set to true.  This means when running the debugger it will not make changes to your system. The [documentation about the puppet agent](https://puppet.com/docs/puppet/5.3/man/apply.html#OPTIONS) has more information about `puppet apply` and and the `noop` option.
 
 - `args` - Additional arguements to pass to `puppet apply`, for example `['--debug']` will output debug information
+
+### Docker Language Server Support
+
+**Note - This is an experimental feature**
+
+The Puppet VSCode extension bundles the Puppet Language Server inside the extension, and loads the language server on demaned and communicates it with either STDIO or TCP. Another option is to communicate via TCP pointed towards a docker container running the Puppet Language Server. The Lingua-Pupuli organization maintains a Puppet Language Server docker container here: https://github.com/lingua-pupuli/images. Using this docker image, we can run the Puppet Language Server without having Puppet Agent or the Puppet Development Kit installed locally, all that is needed is a working docker installation.
+
+Enable using docker by adding the following configuration:
+
+```json
+{
+  "puppet.editorService.protocol":"docker",
+  "puppet.editorService.docker.imageName":"linguapupuli/puppet-language-server:latest"
+}
+```
+
+This will cause the Puppet Extension to instruct docker to start the linguapupuli/puppet-language-server container, then wait for it to start. After starting, the Puppet Extension will use the docker container to perform the same functionality as if it was running locally.
 
 ## Installing the Extension
 

--- a/package.json
+++ b/package.json
@@ -284,6 +284,11 @@
           "default": "",
           "description": "The absolute filepath where the Puppet Editor Service will output the debugging log. By default no logfile is generated"
         },
+        "puppet.editorService.docker.imageName": {
+          "type": "string",
+          "default": "linguapupuli/puppet-language-server:latest",
+          "description": "The name of the image with tag that contains the Puppet Language server. For example: linguapupuli/puppet-language-server:latest"
+        },
         "puppet.editorService.featureFlags": {
           "type": "array",
           "default": [],
@@ -307,7 +312,8 @@
           "description": "The protocol used to communicate with the Puppet Editor Service.  By default the local STDIO protocol is used",
           "enum": [
             "stdio",
-            "tcp"
+            "tcp",
+            "docker"
           ]
         },
         "puppet.editorService.puppet.confdir": {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -102,7 +102,7 @@ export abstract class ConnectionHandler {
     this.setConnectionStatus('Stopped languageserver', ConnectionStatus.Stopped, '');
   }
 
-  private setConnectionStatus(message: string, status: ConnectionStatus, toolTip?: string) {
+  public setConnectionStatus(message: string, status: ConnectionStatus, toolTip?: string) {
     this._status = status;
     this.statusBar.setConnectionStatus(message, status, toolTip);
   }

--- a/src/handlers/docker.ts
+++ b/src/handlers/docker.ts
@@ -1,0 +1,186 @@
+import * as vscode from 'vscode';
+import * as net from 'net';
+import * as cp from 'child_process';
+import { ServerOptions, Executable, StreamInfo } from 'vscode-languageclient';
+
+import { ConnectionHandler } from '../handler';
+import { ConnectionStatus, ConnectionType, IConnectionConfiguration } from '../interfaces';
+import { ISettings } from '../settings';
+import { PuppetStatusBar } from '../PuppetStatusBar';
+import { OutputChannelLogger } from '../logging/outputchannel';
+import { CommandEnvironmentHelper } from '../helpers/commandHelper';
+
+export class DockerConnectionHandler extends ConnectionHandler {
+  private name: string;
+
+  constructor(
+    context: vscode.ExtensionContext,
+    settings: ISettings,
+    statusBar: PuppetStatusBar,
+    logger: OutputChannelLogger,
+    config: IConnectionConfiguration,
+  ) {
+    super(context, settings, statusBar, logger, config);
+    this.logger.debug(`Configuring ${ConnectionType[this.connectionType]}::${this.protocolType} connection handler`);
+
+    /*
+      The docker container will be assigned a random port on creation, so we don't
+      know it unitl we ask via a docker command. Using the unique name created in
+      createUniqueDockerName() we can get the port that the Puppet Language
+      Server is running on in getDockerPort().
+    */
+    this.name = this.createUniqueDockerName();
+
+    let exe: Executable = this.getDockerExecutable(this.name, this.settings.editorService.docker.imageName);
+    this.logger.debug('Editor Services will invoke with: ' + exe.command + ' ' + exe.args.join(' '));
+
+    /*
+      We start the docker container and then listen on stdout for the line that
+      indicates the Puppet Language Server is running and ready to accept
+      connections. This takes some time, so we can't call start() right away.
+      We then call getDockerPort to get the port to connect to.
+    */
+    var proc = cp.spawn(exe.command, exe.args);
+    var isRunning: boolean = false;
+    proc.stdout.on('data', data => {
+      if (/LANGUAGE SERVER RUNNING/.test(data.toString())) {
+        settings.editorService.tcp.port = this.getDockerPort(this.name);
+        isRunning = true;
+        this.start();
+      }
+      if (!isRunning) {
+        this.logger.debug('Editor Service STDOUT: ' + data.toString());
+      }
+    });
+    proc.stderr.on('data', data => {
+      if (!isRunning) {
+        this.logger.debug('Editor Service STDERR: ' + data.toString());
+      }
+    });
+    proc.on('close', exitCode => {
+      this.logger.debug('Editor Service terminated with exit code: ' + exitCode);
+      if (!isRunning) {
+        this.setConnectionStatus('Failure', ConnectionStatus.Failed, 'Could not start the docker container');
+      }
+    });
+  }
+
+  // This is always a remote connection
+  get connectionType(): ConnectionType {
+    return ConnectionType.Remote;
+  }
+
+  createServerOptions(): ServerOptions {
+    let serverOptions = () => {
+      let socket = net.connect({
+        port: this.settings.editorService.tcp.port,
+        host: this.settings.editorService.tcp.address,
+      });
+
+      let result: StreamInfo = {
+        writer: socket,
+        reader: socket,
+      };
+      return Promise.resolve(result);
+    };
+    return serverOptions;
+  }
+
+  /*
+    Options defined in getDockerArguments() should ensure docker cleans up
+    the container on exit, but we do this to ensure the container goes away
+  */
+  cleanup(): void {
+    this.stopLanguageServerDockerProcess(this.name);
+  }
+
+  /*
+    Unlike stdio or tcp, we don't much care about the shell env variables when
+    starting docker containers. We only need docker on the PATH in order for
+    this to work, so we copy what's already there and leave most of it be.
+  */
+  private getDockerExecutable(containerName: string, imageName: string): Executable {
+    let exe: Executable = {
+      command: this.getDockerCommand(process.platform),
+      args: this.getDockerArguments(containerName, imageName),
+      options: {},
+    };
+
+    exe.options.env = CommandEnvironmentHelper.shallowCloneObject(process.env);
+    exe.options.stdio = 'pipe';
+
+    switch (process.platform) {
+      case 'win32':
+        break;
+      default:
+        exe.options.shell = true;
+        break;
+    }
+
+    CommandEnvironmentHelper.cleanEnvironmentPath(exe);
+
+    // undefined or null values still appear in the child spawn environment variables
+    // In this case these elements should be removed from the Object
+    CommandEnvironmentHelper.removeEmptyElements(exe.options.env);
+
+    return exe;
+  }
+
+  /*
+    This creates a sufficiently unique name for a docker container that won't
+    conflict with other containers on a system, but known enough for us to find
+    it if we lose track of it somehow
+  */
+  private createUniqueDockerName() {
+    return 'puppet-vscode-xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      const r = (Math.random() * 16) | 0,
+        v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+
+  /*
+    This uses docker to query what random port was assigned the container we
+    created, and a regex to parse the port number out of the result
+  */
+  private getDockerPort(name: string) {
+    let cmd: string = this.getDockerCommand(process.platform);
+    let args: Array<string> = ['port', name, '8082'];
+    var proc = cp.spawnSync(cmd, args);
+    let regex = /:(\d+)$/m;
+    return Number(regex.exec(proc.stdout.toString())[1]);
+  }
+
+  // this stops and removes docker containers forcibly
+  private stopLanguageServerDockerProcess(name: string): void {
+    let cmd: string = this.getDockerCommand(process.platform);
+    let args: Array<string> = ['rm', '--force', name];
+    let spawn_options: cp.SpawnOptions = {};
+    spawn_options.stdio = 'pipe';
+    cp.spawn(cmd, args, spawn_options);
+  }
+
+  // platform specific docker command
+  private getDockerCommand(platform: string): string {
+    switch (platform) {
+      case 'win32':
+        return 'docker.exe';
+      default:
+        return 'docker';
+    }
+  }
+
+  // docker specific arguments to start the container how we need it started
+  private getDockerArguments(containerName: string, imageName: string) {
+    let args = [
+      'run', // run a new container
+      '--rm', // automatically remove container when it exits
+      '-i', // interactive
+      '-P', // publish all exposed ports to random ports
+      '--name',
+      containerName, // assign a name to the container
+      imageName, // image to use
+    ];
+    return args;
+  }
+}

--- a/src/helpers/commandHelper.ts
+++ b/src/helpers/commandHelper.ts
@@ -48,6 +48,47 @@ export class CommandEnvironmentHelper {
     return exe;
   }
 
+  public static shallowCloneObject(value: Object): Object {
+    const clone: Object = {};
+    for (const propertyName in value) {
+      if (value.hasOwnProperty(propertyName)) {
+        clone[propertyName] = value[propertyName];
+      }
+    }
+    return clone;
+  }
+
+  public static removeEmptyElements(obj: Object) {
+    const propNames = Object.getOwnPropertyNames(obj);
+    for (var i = 0; i < propNames.length; i++) {
+      const propName = propNames[i];
+      if (obj[propName] === null || obj[propName] === undefined) {
+        delete obj[propName];
+      }
+    }
+  }
+
+  public static cleanEnvironmentPath(exe: Executable) {
+    if (exe.options.env.PATH === undefined) {
+      // It's possible that there is no PATH set but unlikely. Due to Object property names being
+      // case sensitive it could simply be that it's called Path or path, particularly on Windows
+      // not so much on Linux etc.. Look through all of the environment names looking for PATH in a
+      // case insensitive way and remove the conflicting env var.
+      let envPath: string = '';
+      Object.keys(exe.options.env).forEach(function(keyname) {
+        if (keyname.match(/^PATH$/i)) {
+          envPath = exe.options.env[keyname];
+          exe.options.env[keyname] = undefined;
+        }
+      });
+      exe.options.env.PATH = envPath;
+    }
+    if (exe.options.env.RUBYLIB === undefined) {
+      exe.options.env.RUBYLIB = '';
+    }
+  }
+
+
   private static buildExecutableCommand(settings: ISettings, config: IConnectionConfiguration) {
     let command: string = '';
     switch (settings.installType) {
@@ -136,43 +177,4 @@ export class CommandEnvironmentHelper {
     return items.join(PathResolver.pathEnvSeparator());
   }
 
-  private static shallowCloneObject(value: Object): Object {
-    const clone: Object = {};
-    for (const propertyName in value) {
-      if (value.hasOwnProperty(propertyName)) {
-        clone[propertyName] = value[propertyName];
-      }
-    }
-    return clone;
-  }
-
-  private static removeEmptyElements(obj: Object) {
-    const propNames = Object.getOwnPropertyNames(obj);
-    for (var i = 0; i < propNames.length; i++) {
-      const propName = propNames[i];
-      if (obj[propName] === null || obj[propName] === undefined) {
-        delete obj[propName];
-      }
-    }
-  }
-
-  private static cleanEnvironmentPath(exe: Executable) {
-    if (exe.options.env.PATH === undefined) {
-      // It's possible that there is no PATH set but unlikely. Due to Object property names being
-      // case sensitive it could simply be that it's called Path or path, particularly on Windows
-      // not so much on Linux etc.. Look through all of the environment names looking for PATH in a
-      // case insensitive way and remove the conflicting env var.
-      let envPath: string = '';
-      Object.keys(exe.options.env).forEach(function (keyname) {
-        if (keyname.match(/^PATH$/i)) {
-          envPath = exe.options.env[keyname];
-          exe.options.env[keyname] = undefined;
-        }
-      });
-      exe.options.env.PATH = envPath;
-    }
-    if (exe.options.env.RUBYLIB === undefined) {
-      exe.options.env.RUBYLIB = '';
-    }
-  }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,6 +31,7 @@ export enum ProtocolType {
   UNKNOWN = '<unknown>',
   STDIO = 'stdio',
   TCP = 'tcp',
+  DOCKER = "docker"
 }
 
 export interface IConnectionConfiguration {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,7 +4,7 @@ import vscode = require("vscode");
 import { ProtocolType, PuppetInstallType } from './interfaces';
 
 export interface IEditorServiceDockerSettings {
-  // Future Use
+  imageName?: string;
 }
 
 export interface IEditorServiceTCPSettings {


### PR DESCRIPTION
This commit adds a new connection handler for a Puppet Language Server
docker container by adding a new setting and protocol. It also extracts
common shell environment helper methods to their own static classes.

This draws heavily from the research and spike done by Michael Lombardi
in PR https://github.com/lingua-pupuli/puppet-vscode/pull/387.

Fixes #375 

Co-authored-by: Michael Lombardi <michael.t.lombardi@outlook.com>