### PR TITLE
(maint) Make regex matching lazy for syntax highlighting

### DIFF
--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -1106,7 +1106,7 @@
     <key>regex-literal</key>
     <dict>
       <key>match</key>
-      <string>(\/)(.+)(?:\/)</string>
+      <string>(\/)(.+?)(?:\/)</string>
       <key>name</key>
       <string>string.regexp.literal.puppet</string>
       <key>comment</key>


### PR DESCRIPTION
The regex used to match regexes in puppet uses (.+) to match one or more
of anything in between two slashes. However, if there is another slash
anywhere on the line after the regex the (.+) will match between the first
slash of the regex and the other slash that's not part of the regex.

An example:

/puppet-agent-5\..*/ => 'puppet5/',

In that line the syntax highlighter will match everything between the first
slash of the regex and the slash in the string as one regex.

This commit simply adds the '?' qualifier to the (.+) matcher to make the
match 'lazy' (i.e. attempt to match the least characters possible) which will
alleviate the issue