### PR TITLE
(GH-295)(GH-288) Add puppetfile support

### DIFF
--- a/languages/puppetfile-language-configuration.json
+++ b/languages/puppetfile-language-configuration.json
@@ -1,0 +1,38 @@
+{
+  "comments": {
+    // symbol used for single line comment. Remove this entry if your language does not support line comments
+    "lineComment": "#",
+    // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+    "blockComment": ["/*","*/"]
+  },
+  // symbols used as brackets
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  // symbols that are auto closed when typing
+  "autoClosingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  // symbols that that can be used to surround a selection
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  // support for region folding
+  "folding": {
+    "offSide": true,
+    "markers": {
+      "start": "^\\s*#\\s*region\\b",
+      "end": "^\\s*#\\s*endregion\\b"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -109,6 +109,10 @@
       {
         "language": "json",
         "path": "./snippets/metadata.snippets.json"
+      },
+      {
+        "language": "puppetfile",
+        "path": "./snippets/puppetfile.snippets.json"
       }
     ],
     "commands": [

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   ],
   "activationEvents": [
     "onLanguage:puppet",
+    "onLanguage:puppetfile",
     "onCommand:extension.puppetShowConnectionLogs",
     "onCommand:extension.puppetShowConnectionMenu",
     "onCommand:extension.puppetLint",
@@ -65,6 +66,17 @@
           ".epp"
         ],
         "configuration": "./languages/puppet-language-configuration.json"
+      },
+      {
+        "id": "puppetfile",
+        "aliases": [
+          "Puppetfile",
+          "PuppetFile"
+        ],
+        "filenames": [
+          "Puppetfile"
+        ],
+        "configuration": "./languages/puppetfile-language-configuration.json"
       }
     ],
     "jsonValidation": [
@@ -82,6 +94,11 @@
         "language": "puppet",
         "scopeName": "source.puppet",
         "path": "./syntaxes/puppet.tmLanguage"
+      },
+      {
+        "language": "puppetfile",
+        "scopeName": "source.ruby",
+        "path": "./syntaxes/puppetfile.cson.json"
       }
     ],
     "snippets": [

--- a/snippets/puppetfile.snippets.json
+++ b/snippets/puppetfile.snippets.json
@@ -1,0 +1,62 @@
+{
+  "Forge_module1": {
+    "prefix": "Forge Module",
+    "body": ["mod '${1:author}-${2:name}', '${3:version}'"],
+    "description": "Install from the forge"
+  },
+  "Forge_module2": {
+    "prefix": "Latest Forge Module",
+    "body": ["mod '${1:author}-${2:name}', :latest"],
+    "description": "Install the latest version from the forge"
+  },
+  "Git_module1": {
+    "prefix": "Git Module by ref",
+    "body": [
+      "mod '${1:name}',",
+      "\t:git => '${2:repository}',",
+      "\t:ref => '${3:reference}'"
+    ],
+    "description": "Install from a git repository specified by a git reference e.g. master"
+  },
+  "Git_module2": {
+    "prefix": "Git Module by commit",
+    "body": [
+      "mod '${1:name}',",
+      "\t:git    => '${2:repository}',",
+      "\t:commit => '${3:commit}'"
+    ],
+    "description": "Install from a git repository specified by a git commit e.g. 1c40e29"
+  },
+  "Git_module3": {
+    "prefix": "Git Module by tag",
+    "body": [
+      "mod '${1:name}',",
+      "\t:git => '${2:repository}',",
+      "\t:tag => '${3:tag}'"
+    ],
+    "description": "Install from a git repository specified by a git tag e.g. v1.0.0"
+  },
+  "Git_module4": {
+    "prefix": "Git Module by branch",
+    "body": [
+      "mod '${1:name}',",
+      "\t:git    => '${2:repository}',",
+      "\t:branch => '${3:branch}'"
+    ],
+    "description": "Install from a git repository specified by a git branch e.g. release"
+  },
+  "Svn_module1": {
+    "prefix": "Svn Module by revision",
+    "body": [
+      "mod '${1:name}',",
+      "\t:svn      => '${2:repository}',",
+      "\t:revision => '${3:revision}'"
+    ],
+    "description": "Install from a SVN repository specified by a revision e.g. 154"
+  },
+  "Local_module1": {
+    "prefix": "Local Module",
+    "body": ["mod '${1:name}', :local => true"],
+    "description": "Install from the local Puppetfile module path"
+  }
+}

--- a/src/PuppetStatusBar.ts
+++ b/src/PuppetStatusBar.ts
@@ -8,7 +8,7 @@ export class PuppetStatusBar {
   statusBarItem: vscode.StatusBarItem;
   private logger: ILogger;
 
-  constructor(langID: string, context:vscode.ExtensionContext, logger: ILogger) {
+  constructor(langIDs: string[], context:vscode.ExtensionContext, logger: ILogger) {
     this.logger = logger;
     context.subscriptions.push(vscode.commands.registerCommand(PuppetCommandStrings.PuppetShowConnectionMenuCommandId,
       () => { PuppetStatusBar.showConnectionMenu(); }
@@ -17,7 +17,7 @@ export class PuppetStatusBar {
     this.statusBarItem.command = PuppetCommandStrings.PuppetShowConnectionMenuCommandId;
     this.statusBarItem.show();
     vscode.window.onDidChangeActiveTextEditor(textEditor => {
-      if (textEditor === undefined || textEditor.document.languageId !== langID) {
+      if (textEditor === undefined || langIDs.indexOf(textEditor.document.languageId) === -1) {
         this.statusBarItem.hide();
       } else {
         this.statusBarItem.show();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,9 @@ import { PuppetStatusBar } from './PuppetStatusBar';
 import { ISettings, legacySettings, settingsFromWorkspace } from './settings';
 import { Reporter, reporter } from './telemetry/telemetry';
 
-const langID = 'puppet'; // don't change this
+export const puppetLangID = 'puppet'; // don't change this
+export const puppetFileLangID = 'puppetfile'; // don't change this
+
 let extContext: vscode.ExtensionContext;
 let connectionHandler: ConnectionHandler;
 let settings: ISettings;
@@ -40,7 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   settings       = settingsFromWorkspace();
   logger         = new OutputChannelLogger(settings);
-  statusBar      = new PuppetStatusBar(langID, context, logger);
+  statusBar      = new PuppetStatusBar([puppetLangID, puppetFileLangID], context, logger);
   configSettings = new ConnectionConfiguration();
 
   if(settings.editorService.enable === false){
@@ -68,8 +70,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   extensionFeatures = [
     new DebugConfigurationFeature(logger, extContext),
-    new FormatDocumentFeature(langID, connectionHandler, settings, logger, extContext),
-    new NodeGraphFeature(langID, connectionHandler, logger, extContext),
+    new FormatDocumentFeature(puppetLangID, connectionHandler, settings, logger, extContext),
+    new NodeGraphFeature(puppetLangID, connectionHandler, logger, extContext),
     new PDKFeature(extContext, logger),
     new PuppetResourceFeature(extContext, connectionHandler, logger)
   ];

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -7,6 +7,7 @@ import { OutputChannelLogger } from './logging/outputchannel';
 import { ISettings } from './settings';
 import { PuppetVersionDetails, PuppetVersionRequest, PuppetCommandStrings } from './messages';
 import { reporter } from './telemetry/telemetry';
+import { puppetFileLangID, puppetLangID} from './extension';
 
 export abstract class ConnectionHandler {
   private timeSpent:number;
@@ -37,7 +38,7 @@ export abstract class ConnectionHandler {
     this.timeSpent = Date.now();
     this.setConnectionStatus('Initializing', ConnectionStatus.Initializing);
 
-    let documents = [{ scheme: 'file', language: 'puppet' }];
+    let documents = [{ scheme: 'file', language: puppetLangID }, { scheme: 'file', language: puppetFileLangID }];
 
     this.logger.debug('Configuring language client options');
     let clientOptions: LanguageClientOptions = {

--- a/syntaxes/puppetfile.cson.json
+++ b/syntaxes/puppetfile.cson.json
@@ -1,0 +1,2724 @@
+{
+  "information_for_contributors": [
+    "This file has copied from https://github.com/rubyide/vscode-ruby/blob/master/syntaxes/ruby.cson.json"
+  ],
+  "version": "https://github.com/atom/language-ruby/commit/f4082a02f467f8b253449d6998226fdea0957efa",
+  "name": "Ruby",
+  "scopeName": "source.ruby",
+  "fileTypes": [
+    "Appfile",
+    "Appraisals",
+    "arb",
+    "Berksfile",
+    "Brewfile",
+    "cap",
+    "Capfile",
+    "capfile",
+    "cgi",
+    "cr",
+    "Dangerfile",
+    "Deliverfile",
+    "Fastfile",
+    "fcgi",
+    "gemspec",
+    "Guardfile",
+    "irbrc",
+    "opal",
+    "Podfile",
+    "podspec",
+    "prawn",
+    "pryrc",
+    "Puppetfile",
+    "rabl",
+    "rake",
+    "Rakefile",
+    "Rantfile",
+    "rb",
+    "rbx",
+    "rjs",
+    "ru",
+    "ruby",
+    "Schemafile",
+    "Snapfile",
+    "thor",
+    "Thorfile",
+    "Vagrantfile"
+  ],
+  "firstLineMatch": "(?x)\n# Hashbang\n^\\#!.*(?:\\s|\\/)\n  (?:ruby|macruby|rake|jruby|rbx|ruby_executable_hooks)\n(?:$|\\s)\n|\n# Modeline\n(?i:\n  # Emacs\n  -\\*-(?:\\s*(?=[^:;\\s]+\\s*-\\*-)|(?:.*?[;\\s]|(?<=-\\*-))mode\\s*:\\s*)\n    ruby\n  (?=[\\s;]|(?<![-*])-\\*-).*?-\\*-\n  |\n  # Vim\n  (?:(?:\\s|^)vi(?:m[<=>]?\\d+|m)?|\\sex)(?=:(?=\\s*set?\\s[^\\n:]+:)|:(?!\\s*set?\\s))(?:(?:\\s|\\s*:\\s*)\\w*(?:\\s*=(?:[^\\n\\\\\\s]|\\\\.)*)?)*[\\s:](?:filetype|ft|syntax)\\s*=\n    ruby\n  (?=\\s|:|$)\n)",
+  "patterns": [
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.control.class.ruby"
+        },
+        "2": {
+          "name": "entity.name.type.class.ruby"
+        },
+        "4": {
+          "name": "entity.other.inherited-class.ruby"
+        },
+        "5": {
+          "name": "punctuation.separator.inheritance.ruby"
+        },
+        "6": {
+          "name": "variable.other.object.ruby"
+        },
+        "7": {
+          "name": "punctuation.definition.variable.ruby"
+        }
+      },
+      "match": "(?x)\n^\\s*(class)\\s+\n(\n  (\n    [.a-zA-Z0-9_:]+\n    (\\s*(<)\\s*[.a-zA-Z0-9_:]+)?   # class A < B\n  )\n  |\n  ((<<)\\s*[.a-zA-Z0-9_:]+)         # class << C\n)",
+      "name": "meta.class.ruby"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.control.module.ruby"
+        },
+        "2": {
+          "name": "entity.name.type.module.ruby"
+        },
+        "3": {
+          "name": "entity.other.inherited-class.module.first.ruby"
+        },
+        "4": {
+          "name": "punctuation.separator.inheritance.ruby"
+        },
+        "5": {
+          "name": "entity.other.inherited-class.module.second.ruby"
+        },
+        "6": {
+          "name": "punctuation.separator.inheritance.ruby"
+        },
+        "7": {
+          "name": "entity.other.inherited-class.module.third.ruby"
+        },
+        "8": {
+          "name": "punctuation.separator.inheritance.ruby"
+        }
+      },
+      "match": "(?x)\n^\\s*(module)\\s+\n(\n  ([A-Z]\\w*(::))?\n  ([A-Z]\\w*(::))?\n  ([A-Z]\\w*(::))*\n  [A-Z]\\w*\n)",
+      "name": "meta.module.ruby"
+    },
+    {
+      "comment": "else if is a common mistake carried over from other languages. it works if you put in a second end, but it’s never what you want.",
+      "match": "(?<!\\.)\\belse(\\s)+if\\b",
+      "name": "invalid.deprecated.ruby"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.hashkey.ruby"
+        }
+      },
+      "comment": "symbols as hash key (1.9 syntax)",
+      "match": "(?>[a-zA-Z_]\\w*(?>[?!])?)(:)(?!:)",
+      "name": "constant.language.symbol.hashkey.ruby"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.ruby"
+        }
+      },
+      "comment": "symbols as hash key (1.8 syntax)",
+      "match": "(?<!:)(:)(?>[a-zA-Z_]\\w*(?>[?!])?)(?=\\s*=>)",
+      "name": "constant.language.symbol.hashkey.ruby"
+    },
+    {
+      "comment": "everything being a reserved word, not a value and needing a 'end' is a..",
+      "match": "(?<!\\.)\\b(BEGIN|begin|case|class|else|elsif|END|end|ensure|for|if|in|module|rescue|then|unless|until|when|while)\\b(?![?!])",
+      "name": "keyword.control.ruby"
+    },
+    {
+      "comment": "contextual smart pair support for block parameters",
+      "match": "(?<!\\.)\\bdo\\b",
+      "name": "keyword.control.start-block.ruby"
+    },
+    {
+      "comment": "contextual smart pair support",
+      "match": "(?<={)(\\s+)",
+      "name": "meta.syntax.ruby.start-block"
+    },
+    {
+      "match": "(?<!\\.)\\b(alias|alias_method|break|next|redo|retry|return|super|undef|yield)\\b(?![?!])|\\bdefined\\?|\\b(block_given|iterator)\\?",
+      "name": "keyword.control.pseudo-method.ruby"
+    },
+    {
+      "match": "\\bnil\\b(?![?!])",
+      "name": "constant.language.nil.ruby"
+    },
+    {
+      "match": "\\b(true|false)\\b(?![?!])",
+      "name": "constant.language.boolean.ruby"
+    },
+    {
+      "match": "\\b(__(FILE|LINE)__)\\b(?![?!])",
+      "name": "variable.language.ruby"
+    },
+    {
+      "match": "\\bself\\b(?![?!])",
+      "name": "variable.language.self.ruby"
+    },
+    {
+      "comment": " everything being a method but having a special function is a..",
+      "match": "\\b(initialize|new|loop|include|extend|prepend|raise|fail|attr_reader|attr_writer|attr_accessor|attr|catch|throw|private|private_class_method|module_function|public|public_class_method|protected|refine|using)\\b(?![?!])",
+      "name": "keyword.other.special-method.ruby"
+    },
+    {
+      "begin": "\\b(?<!\\.|::)(require|require_relative)\\b(?![?!])",
+      "captures": {
+        "1": {
+          "name": "keyword.other.special-method.ruby"
+        }
+      },
+      "end": "$|(?=#|})",
+      "name": "meta.require.ruby",
+      "patterns": [
+        {
+          "include": "$self"
+        }
+      ]
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.variable.ruby"
+        }
+      },
+      "match": "(@)[a-zA-Z_]\\w*",
+      "name": "variable.other.readwrite.instance.ruby"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.variable.ruby"
+        }
+      },
+      "match": "(@@)[a-zA-Z_]\\w*",
+      "name": "variable.other.readwrite.class.ruby"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.variable.ruby"
+        }
+      },
+      "match": "(\\$)[a-zA-Z_]\\w*",
+      "name": "variable.other.readwrite.global.ruby"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.variable.ruby"
+        }
+      },
+      "match": "(\\$)(!|@|&|`|'|\\+|\\d+|~|=|/|\\\\|,|;|\\.|<|>|_|\\*|\\$|\\?|:|\"|-[0adFiIlpv])",
+      "name": "variable.other.readwrite.global.pre-defined.ruby"
+    },
+    {
+      "begin": "\\b(ENV)\\[",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.other.constant.ruby"
+        }
+      },
+      "end": "]",
+      "name": "meta.environment-variable.ruby",
+      "patterns": [
+        {
+          "include": "$self"
+        }
+      ]
+    },
+    {
+      "match": "\\b[A-Z]\\w*(?=((\\.|::)[A-Za-z]|\\[))",
+      "name": "support.class.ruby"
+    },
+    {
+      "match": "\\b((abort|at_exit|autoload|binding|callcc|caller|caller_locations|chomp|chop|eval|exec|exit|fork|format|gets|global_variables|gsub|lambda|load|local_variables|open|p|print|printf|proc|putc|puts|rand|readline|readlines|select|set_trace_func|sleep|spawn|sprintf|srand|sub|syscall|system|test|trace_var|trap|untrace_var|warn)\\b(?![?!])|autoload\\?|exit!)",
+      "name": "support.function.kernel.ruby"
+    },
+    {
+      "match": "\\b[_A-Z]\\w*\\b",
+      "name": "variable.other.constant.ruby"
+    },
+    {
+      "begin": "(?x)\n(?=def\\b)                          # optimization to help Oniguruma fail fast\n(?<=^|\\s)(def)\\s+\n(\n  (?>[a-zA-Z_]\\w*(?>\\.|::))?      # method prefix\n  (?>                               # method name\n    [a-zA-Z_]\\w*(?>[?!]|=(?!>))?\n    |\n    ===?|!=|>[>=]?|<=>|<[<=]?|[%&`/\\|]|\\*\\*?|=?~|[-+]@?|\\[]=?\n  )\n)\n\\s*(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.def.ruby"
+        },
+        "2": {
+          "name": "entity.name.function.ruby"
+        },
+        "3": {
+          "name": "punctuation.definition.parameters.ruby"
+        }
+      },
+      "comment": "The method pattern comes from the symbol pattern. See there for an explanation.",
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.parameters.ruby"
+        }
+      },
+      "name": "meta.function.method.with-arguments.ruby",
+      "patterns": [
+        {
+          "begin": "(?![\\s,)])",
+          "end": "(?=,|\\)\\s*$)",
+          "patterns": [
+            {
+              "captures": {
+                "1": {
+                  "name": "storage.type.variable.ruby"
+                },
+                "2": {
+                  "name": "constant.language.symbol.hashkey.parameter.function.ruby"
+                },
+                "3": {
+                  "name": "punctuation.definition.constant.hashkey.ruby"
+                },
+                "4": {
+                  "name": "variable.parameter.function.ruby"
+                }
+              },
+              "match": "\\G([&*]?)(?:([_a-zA-Z]\\w*(:))|([_a-zA-Z]\\w*))"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?x)\n(?=def\\b)                          # optimization to help Oniguruma fail fast\n(?<=^|\\s)(def)\\s+\n(\n  (?>[a-zA-Z_]\\w*(?>\\.|::))?      # method prefix\n  (?>                               # method name\n    [a-zA-Z_]\\w*(?>[?!]|=(?!>))?\n    |\n    ===?|!=|>[>=]?|<=>|<[<=]?|[%&`/\\|]|\\*\\*?|=?~|[-+]@?|\\[]=?\n  )\n)\n[ \\t]\n(?=[ \\t]*[^\\s#;])                 # make sure the following is not comment",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.def.ruby"
+        },
+        "2": {
+          "name": "entity.name.function.ruby"
+        }
+      },
+      "comment": "same as the previous rule, but without parentheses around the arguments",
+      "end": "$",
+      "name": "meta.function.method.with-arguments.ruby",
+      "patterns": [
+        {
+          "begin": "(?![\\s,])",
+          "end": "(?=,|$)",
+          "patterns": [
+            {
+              "captures": {
+                "1": {
+                  "name": "storage.type.variable.ruby"
+                },
+                "2": {
+                  "name": "constant.language.symbol.hashkey.parameter.function.ruby"
+                },
+                "3": {
+                  "name": "punctuation.definition.constant.hashkey.ruby"
+                },
+                "4": {
+                  "name": "variable.parameter.function.ruby"
+                }
+              },
+              "match": "\\G([&*]?)(?:([_a-zA-Z]\\w*(:))|([_a-zA-Z]\\w*))"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.control.def.ruby"
+        },
+        "3": {
+          "name": "entity.name.function.ruby"
+        }
+      },
+      "comment": " the optional name is just to catch the def also without a method-name",
+      "match": "(?x)\n(?=def\\b)                            # optimization to help Oniguruma fail fast\n(?<=^|\\s)(def)\\b\n(\n  \\s+\n  (\n    (?>[a-zA-Z_]\\w*(?>\\.|::))?      # method prefix\n    (?>                               # method name\n      [a-zA-Z_]\\w*(?>[?!]|=(?!>))?\n      |\n      ===?|!=|>[>=]?|<=>|<[<=]?|[%&`/\\|]|\\*\\*?|=?~|[-+]@?|\\[]=?\n    )\n  )\n)?",
+      "name": "meta.function.method.without-arguments.ruby"
+    },
+    {
+      "match": "(?x)\n\\b\n(\n  [\\d](?>_?\\d)*                             # 100_000\n  (\\.(?![^[:space:][:digit:]])(?>_?\\d)*)?   # fractional part\n  ([eE][-+]?\\d(?>_?\\d)*)?                   # 1.23e-4\n  |\n  0\n  (?:\n    [xX]\\h(?>_?\\h)*|\n    [oO]?[0-7](?>_?[0-7])*|\n    [bB][01](?>_?[01])*|\n    [dD]\\d(?>_?\\d)*\n  )                                           # A base indicator can only be used with an integer\n)\\b",
+      "name": "constant.numeric.ruby"
+    },
+    {
+      "begin": ":'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.symbol.begin.ruby"
+        }
+      },
+      "comment": "symbol literal with '' delimitor",
+      "end": "'",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.symbol.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.ruby",
+      "patterns": [
+        {
+          "match": "\\\\['\\\\]",
+          "name": "constant.character.escape.ruby"
+        }
+      ]
+    },
+    {
+      "begin": ":\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.symbol.begin.ruby"
+        }
+      },
+      "comment": "symbol literal with \"\" delimitor",
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.symbol.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Needs higher precidence than regular expressions.",
+      "match": "(?<!\\()/=",
+      "name": "keyword.operator.assignment.augmented.ruby"
+    },
+    {
+      "begin": "'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "comment": "string literal with '' delimitor",
+      "end": "'",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.single.ruby",
+      "patterns": [
+        {
+          "match": "\\\\'|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        }
+      ]
+    },
+    {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "comment": "string literal with interpolation and \"\" delimitor",
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.double.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "`",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "comment": "execute string (allows for interpolation)",
+      "end": "`",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "(?x)\n(?<![\\w)])((/))(?![?*+])\n(?=\n  (?:\\\\/|[^/])*+          # Do NOT change the order\n  /[eimnosux]*\\s*\n  (?:\n    [)\\]}#.,?:]|\\|\\||&&|<=>|=>|==|=~|!~|!=|;|$|\n    if|else|elsif|then|do|end|unless|while|until|or|and\n  )\n  |\n  $\n)",
+      "captures": {
+        "1": {
+          "name": "string.regexp.interpolated.ruby"
+        },
+        "2": {
+          "name": "punctuation.section.regexp.ruby"
+        }
+      },
+      "comment": "regular expression literal with interpolation",
+      "contentName": "string.regexp.interpolated.ruby",
+      "end": "((/[eimnosux]*))",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        }
+      ]
+    },
+    {
+      "begin": "%r{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.ruby"
+        }
+      },
+      "end": "}[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.ruby"
+        }
+      },
+      "name": "string.regexp.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_curly_r"
+        }
+      ]
+    },
+    {
+      "begin": "%r\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.ruby"
+        }
+      },
+      "end": "][eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.ruby"
+        }
+      },
+      "name": "string.regexp.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_brackets_r"
+        }
+      ]
+    },
+    {
+      "begin": "%r\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.ruby"
+        }
+      },
+      "end": "\\)[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.ruby"
+        }
+      },
+      "name": "string.regexp.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_parens_r"
+        }
+      ]
+    },
+    {
+      "begin": "%r<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.ruby"
+        }
+      },
+      "end": ">[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.ruby"
+        }
+      },
+      "name": "string.regexp.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_ltgt_r"
+        }
+      ]
+    },
+    {
+      "begin": "%r([^\\w])",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.ruby"
+        }
+      },
+      "end": "\\1[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.ruby"
+        }
+      },
+      "name": "string.regexp.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        }
+      ]
+    },
+    {
+      "begin": "%I\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_brackets_i"
+        }
+      ]
+    },
+    {
+      "begin": "%I\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_parens_i"
+        }
+      ]
+    },
+    {
+      "begin": "%I<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": ">",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_ltgt_i"
+        }
+      ]
+    },
+    {
+      "begin": "%I{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_curly_i"
+        }
+      ]
+    },
+    {
+      "begin": "%I([^\\w])",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "\\1",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "%i\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.ruby",
+      "patterns": [
+        {
+          "match": "\\\\]|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    {
+      "begin": "%i\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.ruby",
+      "patterns": [
+        {
+          "match": "\\\\\\)|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_parens"
+        }
+      ]
+    },
+    {
+      "begin": "%i<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": ">",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.ruby",
+      "patterns": [
+        {
+          "match": "\\\\>|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "begin": "%i{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.ruby",
+      "patterns": [
+        {
+          "match": "\\\\}|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_curly"
+        }
+      ]
+    },
+    {
+      "begin": "%i([^\\w])",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "\\1",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.ruby",
+      "patterns": [
+        {
+          "comment": "Cant be named because its not neccesarily an escape.",
+          "match": "\\\\."
+        }
+      ]
+    },
+    {
+      "begin": "%W\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_brackets_i"
+        }
+      ]
+    },
+    {
+      "begin": "%W\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_parens_i"
+        }
+      ]
+    },
+    {
+      "begin": "%W<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": ">",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_ltgt_i"
+        }
+      ]
+    },
+    {
+      "begin": "%W{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_curly_i"
+        }
+      ]
+    },
+    {
+      "begin": "%W([^\\w])",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "\\1",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "%w\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.ruby",
+      "patterns": [
+        {
+          "match": "\\\\]|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    {
+      "begin": "%w\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.ruby",
+      "patterns": [
+        {
+          "match": "\\\\\\)|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_parens"
+        }
+      ]
+    },
+    {
+      "begin": "%w<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": ">",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.ruby",
+      "patterns": [
+        {
+          "match": "\\\\>|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "begin": "%w{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.ruby",
+      "patterns": [
+        {
+          "match": "\\\\}|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_curly"
+        }
+      ]
+    },
+    {
+      "begin": "%w([^\\w])",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.ruby"
+        }
+      },
+      "end": "\\1",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.ruby",
+      "patterns": [
+        {
+          "comment": "Cant be named because its not neccesarily an escape.",
+          "match": "\\\\."
+        }
+      ]
+    },
+    {
+      "begin": "%[Qx]?\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_parens_i"
+        }
+      ]
+    },
+    {
+      "begin": "%[Qx]?\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": "]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_brackets_i"
+        }
+      ]
+    },
+    {
+      "begin": "%[Qx]?{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_curly_i"
+        }
+      ]
+    },
+    {
+      "begin": "%[Qx]?<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": ">",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_ltgt_i"
+        }
+      ]
+    },
+    {
+      "begin": "%[Qx]([^\\w])",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": "\\1",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "%([^\\w\\s=])",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": "\\1",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.interpolated.ruby",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "%q\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.ruby",
+      "patterns": [
+        {
+          "match": "\\\\\\)|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_parens"
+        }
+      ]
+    },
+    {
+      "begin": "%q<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": ">",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.ruby",
+      "patterns": [
+        {
+          "match": "\\\\>|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "begin": "%q\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": "]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.ruby",
+      "patterns": [
+        {
+          "match": "\\\\]|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    {
+      "begin": "%q{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.ruby",
+      "patterns": [
+        {
+          "match": "\\\\}|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_curly"
+        }
+      ]
+    },
+    {
+      "begin": "%q([^\\w])",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": "\\1",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.quoted.other.ruby",
+      "patterns": [
+        {
+          "comment": "Cant be named because its not neccesarily an escape.",
+          "match": "\\\\."
+        }
+      ]
+    },
+    {
+      "begin": "%s\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.symbol.begin.ruby"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.symbol.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.ruby",
+      "patterns": [
+        {
+          "match": "\\\\\\)|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_parens"
+        }
+      ]
+    },
+    {
+      "begin": "%s<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.symbol.begin.ruby"
+        }
+      },
+      "end": ">",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.symbol.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.ruby",
+      "patterns": [
+        {
+          "match": "\\\\>|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "begin": "%s\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.symbol.begin.ruby"
+        }
+      },
+      "end": "]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.symbol.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.ruby",
+      "patterns": [
+        {
+          "match": "\\\\]|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    {
+      "begin": "%s{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.symbol.begin.ruby"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.symbol.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.ruby",
+      "patterns": [
+        {
+          "match": "\\\\}|\\\\\\\\",
+          "name": "constant.character.escape.ruby"
+        },
+        {
+          "include": "#nest_curly"
+        }
+      ]
+    },
+    {
+      "begin": "%s([^\\w])",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.symbol.begin.ruby"
+        }
+      },
+      "end": "\\1",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.symbol.end.ruby"
+        }
+      },
+      "name": "constant.language.symbol.ruby",
+      "patterns": [
+        {
+          "comment": "Cant be named because its not neccesarily an escape.",
+          "match": "\\\\."
+        }
+      ]
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.ruby"
+        }
+      },
+      "comment": "symbols",
+      "match": "(?x)\n(?<!:)(:)\n(?>\n  [$a-zA-Z_]\\w*(?>[?!]|=(?![>=]))?\n  |\n  ===?|<=>|>[>=]?|<[<=]?|[%&`/\\|]|\\*\\*?|=?~|[-+]@?|\\[]=?\n  |\n  @@?[a-zA-Z_]\\w*\n)",
+      "name": "constant.language.symbol.ruby"
+    },
+    {
+      "begin": "^=begin",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.ruby"
+        }
+      },
+      "comment": "multiline comments",
+      "end": "^=end",
+      "name": "comment.block.documentation.ruby"
+    },
+    {
+      "begin": "(^[ \\t]+)?(?=#)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.whitespace.comment.leading.ruby"
+        }
+      },
+      "end": "(?!\\G)",
+      "patterns": [
+        {
+          "begin": "#",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.ruby"
+            }
+          },
+          "end": "\\n",
+          "name": "comment.line.number-sign.ruby",
+          "patterns": [
+            {
+              "include": "#yard"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "comment": "\n\t\t\tmatches questionmark-letters.\n\n\t\t\texamples (1st alternation = hex):\n\t\t\t?\\x1     ?\\x61\n\n\t\t\texamples (2nd alternation = octal):\n\t\t\t?\\0      ?\\07     ?\\017\n\n\t\t\texamples (3rd alternation = escaped):\n\t\t\t?\\n      ?\\b\n\n\t\t\texamples (4th alternation = meta-ctrl):\n\t\t\t?\\C-a    ?\\M-a    ?\\C-\\M-\\C-\\M-a\n\n\t\t\texamples (4th alternation = normal):\n\t\t\t?a       ?A       ?0 \n\t\t\t?*       ?\"       ?( \n\t\t\t?.       ?#\n\t\t\t\n\t\t\t\n\t\t\tthe negative lookbehind prevents against matching\n\t\t\tp(42.tainted?)\n\t\t\t",
+      "match": "(?<!\\w)\\?(\\\\(x\\h{1,2}(?!\\h)\\b|0[0-7]{0,2}(?![0-7])\\b|[^x0MC])|(\\\\[MC]-)+\\w|[^\\s\\\\])",
+      "name": "constant.numeric.ruby"
+    },
+    {
+      "begin": "^__END__\\n",
+      "captures": {
+        "0": {
+          "name": "string.unquoted.program-block.ruby"
+        }
+      },
+      "comment": "__END__ marker",
+      "contentName": "text.plain",
+      "end": "(?=not)impossible",
+      "patterns": [
+        {
+          "begin": "(?=<?xml|<(?i:html\\b)|!DOCTYPE (?i:html\\b))",
+          "end": "(?=not)impossible",
+          "name": "text.html.embedded.ruby",
+          "patterns": [
+            {
+              "include": "text.html.basic"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)HTML)\\b\\1))",
+      "comment": "Heredoc with embedded html",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.html",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)HTML)\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "text.html",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "text.html.basic"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)XML)\\b\\1))",
+      "comment": "Heredoc with embedded xml",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.xml",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)XML)\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "text.xml",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "text.xml"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)SQL)\\b\\1))",
+      "comment": "Heredoc with embedded sql",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.sql",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)SQL)\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "source.sql",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "source.sql"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)GRAPHQL)\\b\\1))",
+      "comment": "Heredoc with embedded GraphQL",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.graphql",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)GRAPHQL)\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "source.graphql",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "source.graphql"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)CSS)\\b\\1))",
+      "comment": "Heredoc with embedded css",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.css",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)CSS)\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "source.css",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "source.css"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)CPP)\\b\\1))",
+      "comment": "Heredoc with embedded c++",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.cpp",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)CPP)\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "source.cpp",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "source.cpp"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)C)\\b\\1))",
+      "comment": "Heredoc with embedded c",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.c",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)C)\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "source.c",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "source.c"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1))",
+      "comment": "Heredoc with embedded javascript",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.js",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "source.js",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "source.js"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)JQUERY)\\b\\1))",
+      "comment": "Heredoc with embedded jQuery javascript",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.js.jquery",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)JQUERY)\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "source.js.jquery",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "source.js.jquery"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1))",
+      "comment": "Heredoc with embedded shell",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.shell",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "source.shell",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "source.shell"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)LUA)\\b\\1))",
+      "comment": "Heredoc with embedded lua",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.lua",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)LUA)\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "source.lua",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "source.lua"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)RUBY)\\b\\1))",
+      "comment": "Heredoc with embedded ruby",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.ruby",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)RUBY)\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "source.ruby",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "source.ruby"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(?>=\\s*<<([\"'`]?)(\\w+)\\1)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": "^\\2$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.unquoted.heredoc.ruby",
+      "patterns": [
+        {
+          "include": "#heredoc"
+        },
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "(?>((<<[-~]([\"'`]?)(\\w+)\\3,\\s?)*<<[-~]([\"'`]?)(\\w+)\\5))",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "comment": "heredoc with multiple inputs and indented terminator",
+      "end": "^\\s*\\6$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "name": "string.unquoted.heredoc.ruby",
+      "patterns": [
+        {
+          "include": "#heredoc"
+        },
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "(?<={|{\\s|[^A-Za-z0-9_]do|^do|[^A-Za-z0-9_]do\\s|^do\\s)(\\|)",
+      "captures": {
+        "1": {
+          "name": "punctuation.separator.variable.ruby"
+        }
+      },
+      "end": "(?<!\\|)(\\|)(?!\\|)",
+      "patterns": [
+        {
+          "include": "source.ruby"
+        },
+        {
+          "match": "[_a-zA-Z][_a-zA-Z0-9]*",
+          "name": "variable.other.block.ruby"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.variable.ruby"
+        }
+      ]
+    },
+    {
+      "match": "=>",
+      "name": "punctuation.separator.key-value"
+    },
+    {
+      "match": "->",
+      "name": "support.function.kernel.ruby"
+    },
+    {
+      "match": "<<=|%=|&{1,2}=|\\*=|\\*\\*=|\\+=|-=|\\^=|\\|{1,2}=|<<",
+      "name": "keyword.operator.assignment.augmented.ruby"
+    },
+    {
+      "match": "<=>|<(?!<|=)|>(?!<|=|>)|<=|>=|===|==|=~|!=|!~|(?<=[ \\t])\\?",
+      "name": "keyword.operator.comparison.ruby"
+    },
+    {
+      "match": "(?<!\\.)\\b(and|not|or)\\b(?![?!])",
+      "name": "keyword.operator.logical.ruby"
+    },
+    {
+      "match": "(?<=^|[ \\t])!|&&|\\|\\||\\^",
+      "name": "keyword.operator.logical.ruby"
+    },
+    {
+      "comment": "Safe navigation operator",
+      "match": "(&\\.)\\s*(?![A-Z])",
+      "captures": {
+        "1": {
+          "name": "punctuation.separator.method.ruby"
+        }
+      }
+    },
+    {
+      "match": "(%|&|\\*\\*|\\*|\\+|-|/)",
+      "name": "keyword.operator.arithmetic.ruby"
+    },
+    {
+      "match": "=",
+      "name": "keyword.operator.assignment.ruby"
+    },
+    {
+      "match": "\\||~|>>",
+      "name": "keyword.operator.other.ruby"
+    },
+    {
+      "match": ";",
+      "name": "punctuation.separator.statement.ruby"
+    },
+    {
+      "match": ",",
+      "name": "punctuation.separator.object.ruby"
+    },
+    {
+      "comment": "Mark as namespace separator if double colons followed by capital letter",
+      "match": "(::)\\s*(?=[A-Z])",
+      "captures": {
+        "1": {
+          "name": "punctuation.separator.namespace.ruby"
+        }
+      }
+    },
+    {
+      "comment": "Mark as method separator if double colons not followed by capital letter",
+      "match": "(\\.|::)\\s*(?![A-Z])",
+      "captures": {
+        "1": {
+          "name": "punctuation.separator.method.ruby"
+        }
+      }
+    },
+    {
+      "comment": "Must come after method and constant separators to prefer double colons",
+      "match": ":",
+      "name": "punctuation.separator.other.ruby"
+    },
+    {
+      "match": "{",
+      "name": "punctuation.section.scope.begin.ruby"
+    },
+    {
+      "match": "}",
+      "name": "punctuation.section.scope.end.ruby"
+    },
+    {
+      "match": "\\[",
+      "name": "punctuation.section.array.begin.ruby"
+    },
+    {
+      "match": "]",
+      "name": "punctuation.section.array.end.ruby"
+    },
+    {
+      "match": "\\(|\\)",
+      "name": "punctuation.section.function.ruby"
+    },
+    {
+      "begin": "(?=[a-zA-Z0-9_!?]+\\()",
+      "end": "(?<=\\))",
+      "name": "meta.function-call.ruby",
+      "patterns": [
+        {
+          "include": "#nest_function_parens"
+        },
+        {
+          "include": "#known_function_names"
+        },
+        {
+          "match": "([a-zA-Z0-9_!?]+)(?=\\()",
+          "name": "entity.name.function.ruby"
+        },
+        {
+          "include": "$self"
+        }
+      ]
+    },
+    {
+      "comment": "This is kindof experimental. There really is no way to perfectly match all regular variables, but you can pretty well assume that any normal word in certain curcumstances that havnt already been scoped as something else are probably variables, and the advantages beat the potential errors",
+      "match": "((?<=\\W)\\b|^)\\w+\\b(?=\\s*([\\]\\)\\}\\=\\+\\-\\*\\/\\^\\$\\,\\.]|<\\s|<<[\\s|\\.]))",
+      "name": "variable.other.ruby"
+    }
+  ],
+  "repository": {
+    "escaped_char": {
+      "match": "\\\\(?:[0-7]{1,3}|x[\\da-fA-F]{1,2}|.)",
+      "name": "constant.character.escape.ruby"
+    },
+    "heredoc": {
+      "begin": "^<<[-~]?\\w+",
+      "end": "$",
+      "patterns": [
+        {
+          "include": "$self"
+        }
+      ]
+    },
+    "interpolated_ruby": {
+      "patterns": [
+        {
+          "begin": "#{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.begin.ruby"
+            }
+          },
+          "contentName": "source.ruby",
+          "end": "}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.end.ruby"
+            }
+          },
+          "name": "meta.embedded.line.ruby",
+          "patterns": [
+            {
+              "include": "#nest_curly_and_self"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.variable.ruby"
+            }
+          },
+          "match": "(#@)[a-zA-Z_]\\w*",
+          "name": "variable.other.readwrite.instance.ruby"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.variable.ruby"
+            }
+          },
+          "match": "(#@@)[a-zA-Z_]\\w*",
+          "name": "variable.other.readwrite.class.ruby"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.variable.ruby"
+            }
+          },
+          "match": "(#\\$)[a-zA-Z_]\\w*",
+          "name": "variable.other.readwrite.global.ruby"
+        }
+      ]
+    },
+    "nest_brackets": {
+      "begin": "\\[",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.scope.ruby"
+        }
+      },
+      "end": "]",
+      "patterns": [
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    "nest_brackets_i": {
+      "begin": "\\[",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.scope.ruby"
+        }
+      },
+      "end": "]",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_brackets_i"
+        }
+      ]
+    },
+    "nest_brackets_r": {
+      "begin": "\\[",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.scope.ruby"
+        }
+      },
+      "end": "]",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_brackets_r"
+        }
+      ]
+    },
+    "nest_curly": {
+      "begin": "{",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.scope.ruby"
+        }
+      },
+      "end": "}",
+      "patterns": [
+        {
+          "include": "#nest_curly"
+        }
+      ]
+    },
+    "nest_curly_and_self": {
+      "patterns": [
+        {
+          "begin": "{",
+          "captures": {
+            "0": {
+              "name": "punctuation.section.scope.ruby"
+            }
+          },
+          "end": "}",
+          "patterns": [
+            {
+              "include": "#nest_curly_and_self"
+            }
+          ]
+        },
+        {
+          "include": "$self"
+        }
+      ]
+    },
+    "nest_curly_i": {
+      "begin": "{",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.scope.ruby"
+        }
+      },
+      "end": "}",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_curly_i"
+        }
+      ]
+    },
+    "nest_curly_r": {
+      "begin": "{",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.scope.ruby"
+        }
+      },
+      "end": "}",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_curly_r"
+        }
+      ]
+    },
+    "nest_ltgt": {
+      "begin": "<",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.scope.ruby"
+        }
+      },
+      "end": ">",
+      "patterns": [
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    "nest_ltgt_i": {
+      "begin": "<",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.scope.ruby"
+        }
+      },
+      "end": ">",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_ltgt_i"
+        }
+      ]
+    },
+    "nest_ltgt_r": {
+      "begin": "<",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.scope.ruby"
+        }
+      },
+      "end": ">",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_ltgt_r"
+        }
+      ]
+    },
+    "nest_parens": {
+      "begin": "\\(",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.scope.ruby"
+        }
+      },
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#nest_parens"
+        }
+      ]
+    },
+    "nest_parens_i": {
+      "begin": "\\(",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.scope.ruby"
+        }
+      },
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_parens_i"
+        }
+      ]
+    },
+    "nest_parens_r": {
+      "begin": "\\(",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.scope.ruby"
+        }
+      },
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_parens_r"
+        }
+      ]
+    },
+    "regex_sub": {
+      "patterns": [
+        {
+          "include": "#interpolated_ruby"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.arbitrary-repetition.ruby"
+            },
+            "3": {
+              "name": "punctuation.definition.arbitrary-repetition.ruby"
+            }
+          },
+          "match": "({)\\d+(,\\d+)?(})",
+          "name": "string.regexp.arbitrary-repetition.ruby"
+        },
+        {
+          "begin": "\\[(?:\\^?])?",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.character-class.ruby"
+            }
+          },
+          "end": "]",
+          "name": "string.regexp.character-class.ruby",
+          "patterns": [
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "\\(\\?#",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.begin.ruby"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.end.ruby"
+            }
+          },
+          "name": "comment.line.number-sign.ruby",
+          "patterns": [
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "\\(",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.group.ruby"
+            }
+          },
+          "end": "\\)",
+          "name": "string.regexp.group.ruby",
+          "patterns": [
+            {
+              "include": "#regex_sub"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=^|\\s)(#)\\s(?=[[a-zA-Z0-9,. \\t?!-][^\\x{00}-\\x{7F}]]*$)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.comment.ruby"
+            }
+          },
+          "comment": "We are restrictive in what we allow to go after the comment character to avoid false positives, since the availability of comments depend on regexp flags.",
+          "end": "$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.ruby"
+            }
+          },
+          "name": "comment.line.number-sign.ruby"
+        }
+      ]
+    },
+    "yard": {
+      "name": "comment.line.yard.ruby",
+      "patterns": [
+        {
+          "include": "#yard_comment"
+        },
+        {
+          "include": "#yard_name_types"
+        },
+        {
+          "include": "#yard_tag"
+        },
+        {
+          "include": "#yard_types"
+        },
+        {
+          "include": "#yard_directive"
+        }
+      ]
+    },
+    "yard_comment": {
+      "comment": "For YARD tags that follow the tag-comment pattern",
+      "match": "(@)(abstract|api|author|deprecated|example|note|overload|since|todo|version)(?=\\s)(.*)$",
+      "captures": {
+        "1": {
+          "name": "comment.line.keyword.punctuation.yard.ruby"
+        },
+        "2": {
+          "name": "comment.line.keyword.yard.ruby"
+        },
+        "3": {
+          "name": "comment.line.string.yard.ruby"
+        }
+      }
+    },
+    "yard_name_types": {
+      "comment": "For YARD tags that follow the tag-name-types-comment pattern",
+      "match": "(@)(attr|attr_reader|attr_writer|option|param|see|yieldparam)(?=\\s)(\\s+([a-z_][a-zA-Z_]*))?(\\s+((\\[).+(])))?(.*)$",
+      "captures": {
+        "1": {
+          "name": "comment.line.keyword.punctuation.yard.ruby"
+        },
+        "2": {
+          "name": "comment.line.keyword.yard.ruby"
+        },
+        "3": {
+          "name": "comment.line.yard.ruby"
+        },
+        "4": {
+          "name": "comment.line.parameter.yard.ruby"
+        },
+        "5": {
+          "name": "comment.line.yard.ruby"
+        },
+        "6": {
+          "name": "comment.line.type.yard.ruby"
+        },
+        "7": {
+          "name": "comment.line.punctuation.yard.ruby"
+        },
+        "8": {
+          "name": "comment.line.punctuation.yard.ruby"
+        },
+        "9": {
+          "name": "comment.line.string.yard.ruby"
+        }
+      }
+    },
+    "yard_tag": {
+      "comment": "For YARD tags that are just the tag",
+      "match": "(@)(private)$",
+      "captures": {
+        "1": {
+          "name": "comment.line.keyword.punctuation.yard.ruby"
+        },
+        "2": {
+          "name": "comment.line.keyword.yard.ruby"
+        }
+      }
+    },
+    "yard_types": {
+      "comment": "For YARD tags that follow the tag-types-comment pattern",
+      "match": "(@)(raise|return|yield(?:return)?)(?=\\s)(\\s+((\\[).+(])))?(.*)$",
+      "captures": {
+        "1": {
+          "name": "comment.line.keyword.punctuation.yard.ruby"
+        },
+        "2": {
+          "name": "comment.line.keyword.yard.ruby"
+        },
+        "3": {
+          "name": "comment.line.yard.ruby"
+        },
+        "4": {
+          "name": "comment.line.type.yard.ruby"
+        },
+        "5": {
+          "name": "comment.line.punctuation.yard.ruby"
+        },
+        "6": {
+          "name": "comment.line.punctuation.yard.ruby"
+        },
+        "7": {
+          "name": "comment.line.string.yard.ruby"
+        }
+      }
+    },
+    "yard_directive": {
+      "comment": "For YARD directives",
+      "match": "(@!)(attribute|endgroup|group|macro|method|parse|scope|visibility)(\\s+((\\[).+(])))?(?=\\s)(.*)$",
+      "captures": {
+        "1": {
+          "name": "comment.line.keyword.punctuation.yard.ruby"
+        },
+        "2": {
+          "name": "comment.line.keyword.yard.ruby"
+        },
+        "3": {
+          "name": "comment.line.yard.ruby"
+        },
+        "4": {
+          "name": "comment.line.type.yard.ruby"
+        },
+        "5": {
+          "name": "comment.line.punctuation.yard.ruby"
+        },
+        "6": {
+          "name": "comment.line.punctuation.yard.ruby"
+        },
+        "7": {
+          "name": "comment.line.string.yard.ruby"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Previously the control repo configuration file (Puppetfile) was not set as
the puppet language which meant that although the Editor Services knew how
to process the file, VSCode would not send requests to it.

This commit;

* Updates the package.json to contribute a new language called `puppetfile`
  which is associated with files called `Puppetfile`
* Adds a language configuration for puppetfile, which is just a copy of the
  puppet configuration
* Adds syntax highlighting for Puppetfile as a copy from the ruby syntax
  highlighter.  This is because Puppetfile's are actually interpretted as ruby
* Modifies the Language Client to associated puppet and puppetfile with the
  Puppet Language Server
* Modifies the Status Bar to display for puppet and puppetfile language files

Fixes #295 
Fixes #288 