### PR TITLE
(GH-454) Fix PDK Ruby file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
     - [Puppet Resource](#puppet-resource)
     - [Puppet Node Graph](#puppet-node-graph)
   - [Puppet Development Kit Support](#puppet-development-kit-support)
+    - [PDK Supported Versions](#pdk-supported-versions)
     - [PDK New Module](#pdk-new-module)
     - [PDK New Class](#pdk-new-class)
     - [PDK Validate](#pdk-validate)
@@ -212,6 +213,10 @@ You can use the [Puppet Development Kit](https://puppet.com/blog/develop-modules
 > Note: The PDK must be installed prior to using these commands
 
 > Note: `pdk convert` is not available in the command palette as it is a complicated command that requires user input to succeed. It is better to use it from the builtin terminal.
+
+#### PDK Supported Versions
+
+The Puppet VSCode Extension supports the current PDK version, and one older version. This is currently 1.8.0 and 1.7.1.
 
 #### PDK new module
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -13,6 +13,8 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
   public timeout: number;
   public debugFilePath: string;
   private settings: ISettings;
+  private gemRubyVersionDir: string;
+  private rubyVersionDir: string;
 
   constructor() {
     this.settings = settingsFromWorkspace();
@@ -23,6 +25,9 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
     this.debugFilePath = this.settings.editorService.debugFilePath;
 
     this._puppetInstallType = this.settings.installType;
+
+    this.rubyVersionDir    = '2.5.1';
+    this.gemRubyVersionDir = '2.5.0';
   }
 
   private _puppetInstallType: PuppetInstallType;
@@ -207,16 +212,14 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
 
   get pdkRubyVerDir(): string {
     var rootDir = path.join(this.puppetBaseDir, 'private', 'puppet', 'ruby');
-    var versionDir = '2.4.0';
 
-    return PathResolver.resolveSubDirectory(rootDir, versionDir);
+    return path.join(rootDir, this.gemRubyVersionDir);
   }
 
   get pdkGemDir(): string {
     // GEM_HOME=C:\Users\user\AppData\Local/PDK/cache/ruby/2.4.0
     var rootDir = path.join(this.puppetBaseDir, 'share', 'cache', 'ruby');
-    var versionDir = '2.4.0';
-    var directory = PathResolver.resolveSubDirectory(rootDir, versionDir);
+    var directory = path.join(rootDir, this.gemRubyVersionDir);
 
     if (process.platform === 'win32') {
       // Translate all slashes to / style to avoid puppet/ruby issue #11930
@@ -227,9 +230,8 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
 
   get pdkRubyDir(): string {
     var rootDir = path.join(this.puppetBaseDir, 'private', 'ruby');
-    var versionDir = '2.4.4';
 
-    return PathResolver.resolveSubDirectory(rootDir, versionDir);
+    return path.join(rootDir, this.rubyVersionDir);;
   }
 
   get pdkRubyBinDir(): string {
@@ -238,9 +240,8 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
 
   get pdkGemVerDir(): string {
     var rootDir = path.join(this.pdkRubyDir, 'lib', 'ruby', 'gems');
-    var versionDir = '2.4.0';
 
-    return PathResolver.resolveSubDirectory(rootDir, versionDir);
+    return path.join(rootDir, this.gemRubyVersionDir);;
   }
 
   // GEM_PATH=C:/Program Files/Puppet Labs/DevelopmentKit/private/ruby/2.4.4/lib/ruby/gems/2.4.0;C:/Program Files/Puppet Labs/DevelopmentKit/share/cache/ruby/2.4.0;C:/Program Files/Puppet Labs/DevelopmentKit/private/puppet/ruby/2.4.0

--- a/src/handlers/stdio.ts
+++ b/src/handlers/stdio.ts
@@ -39,7 +39,7 @@ export class StdioConnectionHandler extends ConnectionHandler {
         logPrefix = '[getRubyEnvFromPDK] ';
         this.logger.debug(logPrefix + 'Using environment variable DEVKIT_BASEDIR=' + exe.options.env.DEVKIT_BASEDIR);
         this.logger.debug(logPrefix + 'Using environment variable GEM_HOME=' + exe.options.env.GEM_HOME);
-        this.logger.debug(logPrefix + 'Using environment variable GEM_HOME=' + exe.options.env.GEM_HOME);
+        this.logger.debug(logPrefix + 'Using environment variable GEM_PATH=' + exe.options.env.GEM_PATH);
         break;
       case PuppetInstallType.PUPPET:
         logPrefix = '[getRubyExecFromPuppetAgent] ';


### PR DESCRIPTION
This commit updates the default Ruby version from 2.4.0 to 2.5.1 used
when using PDK as the source for the Puppet Language Server. Ruby 2.5.1
is in PDK 1.7.1 and PDK 1.8.0 so it is safe to use as default until we
can land a feature to allow the user to pick between available PDK ruby
versions.