### PR TITLE
(GH-453) Expose advanced additional Editor Service Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,11 +301,6 @@
             "verbose"
           ]
         },
-        "puppet.editorService.modulePath": {
-          "type": "string",
-          "default": "",
-          "description": "Additional module paths to use when starting the Editor Services. On Windows this is delimited with a semicolon, and on all other platforms, with a colon. For example C:\\Path1;C:\\Path2"
-        },
         "puppet.editorService.protocol": {
           "type": "string",
           "default": "stdio",
@@ -314,6 +309,26 @@
             "stdio",
             "tcp"
           ]
+        },
+        "puppet.editorService.puppet.confdir": {
+          "type": "string",
+          "default": "",
+          "description": "The Puppet configuration directory. See https://puppet.com/docs/puppet/latest/dirs_confdir.html for more information"
+        },
+        "puppet.editorService.puppet.environment": {
+          "type": "string",
+          "default": "",
+          "description": "The Puppet environment to use. See https://puppet.com/docs/puppet/latest/config_print.html#environments for more information"
+        },
+        "puppet.editorService.puppet.modulePath": {
+          "type": "string",
+          "default": "",
+          "description": "Additional module paths to use when starting the Editor Services. On Windows this is delimited with a semicolon, and on all other platforms, with a colon. For example C:\\Path1;C:\\Path2"
+        },
+        "puppet.editorService.puppet.vardir": {
+          "type": "string",
+          "default": "",
+          "description": "The Puppet cache directory. See https://puppet.com/docs/puppet/latest/dirs_vardir.html for more information"
         },
         "puppet.editorService.tcp.address": {
           "type": "string",
@@ -347,6 +362,9 @@
             "pdk",
             "agent"
           ]
+        },
+        "puppet.editorService.modulePath": {
+          "description": "**DEPRECATED** Please use puppet.editorService.puppet.modulePath instead"
         },
         "puppet.languageclient.protocol": {
           "description": "**DEPRECATED** Please use puppet.editorService.protocol instead"

--- a/src/handlers/stdio.ts
+++ b/src/handlers/stdio.ts
@@ -52,6 +52,7 @@ export class StdioConnectionHandler extends ConnectionHandler {
     this.logger.debug(logPrefix + 'Using environment variable RUBYLIB=' + exe.options.env.RUBYLIB);
     this.logger.debug(logPrefix + 'Using environment variable PATH=' + exe.options.env.PATH);
     this.logger.debug(logPrefix + 'Using environment variable RUBYOPT=' + exe.options.env.RUBYOPT);
+    this.logger.debug(logPrefix + 'Editor Services will invoke with: ' + exe.command + ' ' + exe.args.join(' '));
 
     let serverOptions: ServerOptions = {
       run: exe,

--- a/src/handlers/tcp.ts
+++ b/src/handlers/tcp.ts
@@ -50,6 +50,7 @@ export class TcpConnectionHandler extends ConnectionHandler {
       let spawn_options: cp.SpawnOptions = {};
       let convertedOptions = Object.assign(spawn_options, exe.options);
 
+      this.logger.debug(logPrefix + 'Editor Services will invoke with: ' + exe.command + ' ' + exe.args.join(' '));
       var proc = cp.spawn(exe.command, exe.args, convertedOptions);
       proc.stdout.on('data', data => {
         if (/LANGUAGE SERVER RUNNING/.test(data.toString())) {

--- a/src/helpers/commandHelper.ts
+++ b/src/helpers/commandHelper.ts
@@ -89,9 +89,24 @@ export class CommandEnvironmentHelper {
     if (vscode.workspace.workspaceFolders !== undefined) {
       args.push('--local-workspace=' + vscode.workspace.workspaceFolders[0].uri.fsPath);
     }
-    if (settings.editorService.modulePath !== undefined && settings.editorService.modulePath !== '') {
-      args.push('--puppet-settings=--modulepath,' + settings.editorService.modulePath);
+
+    // Convert the individual puppet settings into the --puppet-settings
+    // command line argument
+    let puppetSettings: string[] = [];
+    [
+      { name: 'confdir', value: settings.editorService.puppet.confdir },
+      { name: 'environment', value: settings.editorService.puppet.environment },
+      { name: 'modulePath', value: settings.editorService.puppet.modulePath },
+      { name: 'vardir', value: settings.editorService.puppet.vardir }
+    ].forEach(function (item) {
+      if (item.value !== undefined && item.value !== '') {
+        puppetSettings.push('--' + item.name + ',' + item.value);
+      }
+    });
+    if (puppetSettings.length > 0) {
+      args.push('--puppet-settings=' + puppetSettings.join(','));
     }
+
     if (settings.editorService.debugFilePath !== undefined && settings.editorService.debugFilePath !== '') {
       args.push('--debug=' + settings.editorService.debugFilePath);
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,14 +12,21 @@ export interface IEditorServiceTCPSettings {
   port?: number;
 }
 
+export interface IEditorServicePuppetSettings {
+  confdir?: string;
+  environment?: string;
+  modulePath?: string;
+  vardir?: string;
+}
+
 export interface IEditorServiceSettings {
   debugFilePath?: string;
   docker?: IEditorServiceDockerSettings;
   enable?: boolean;
   featureflags?: string[];
-  modulePath?: string;
   loglevel?: string;
   protocol?: ProtocolType;
+  puppet?: IEditorServicePuppetSettings;
   tcp?: IEditorServiceTCPSettings;
   timeout?: number;
 }
@@ -79,6 +86,10 @@ export function legacySettings(): Map<string, Object> {
   let settings: Map<string, Object> = new Map<string, Object>();
   let value: Object = undefined;
 
+  // puppet.editorService.modulePath
+  value = getSafeWorkspaceConfig(workspaceConfig, ['editorService','modulePath']);
+  if (value !== undefined) { settings.set("puppet.editorService.modulePath", value); }
+
   // puppet.languageclient.minimumUserLogLevel
   value = getSafeWorkspaceConfig(workspaceConfig, ['languageclient','minimumUserLogLevel']);
   if (value !== undefined) { settings.set("puppet.languageclient.minimumUserLogLevel", value); }
@@ -120,7 +131,6 @@ export function settingsFromWorkspace(): ISettings {
     enable: true,
     featureflags: [],
     loglevel: "normal",
-    modulePath: "",
     protocol: ProtocolType.STDIO,
     timeout: 10,
   };
@@ -157,6 +167,7 @@ export function settingsFromWorkspace(): ISettings {
    // Ensure that object types needed for legacy settings exists
   if (settings.editorService === undefined) { settings.editorService = {}; }
   if (settings.editorService.featureflags === undefined) { settings.editorService.featureflags = []; }
+  if (settings.editorService.puppet === undefined) { settings.editorService.puppet = {}; }
   if (settings.editorService.tcp === undefined) { settings.editorService.tcp = {}; }
 
   // Retrieve the legacy settings
@@ -165,6 +176,10 @@ export function settingsFromWorkspace(): ISettings {
   // Translate the legacy settings into the new setting names
   for (const [settingName, value] of oldSettings) {
     switch (settingName) {
+
+      case "puppet.editorService.modulePath": // --> puppet.editorService.puppet.modulePath
+        settings.editorService.puppet.modulePath = <string>value;
+        break;
 
       case "puppet.languageclient.minimumUserLogLevel": // --> puppet.editorService.loglevel
         settings.editorService.loglevel = <string>value;


### PR DESCRIPTION
Previously in Editor Services version 0.17.0 the --puppet-settings
parameter was introduced.  While it's kind of used by the modulepath
settings, users still couldn't modify it directly e.g. confdir.

This commit;
* Adds a settings called
  puppet.editorService.puppet.confdir
  puppet.editorService.puppet.environment
  puppet.editorService.puppet.modulePath
  puppet.editorService.puppet.vardir
* Injects this setting into the editor service commandline if set
* Deprecates the puppet.editorService.modulePath setting and instead
  use ...puppet.modulePath

Fixes #453 