### PR TITLE
(GH-288) Change puppetfile snippets to single line

### DIFF
--- a/snippets/puppetfile.snippets.json
+++ b/snippets/puppetfile.snippets.json
@@ -12,45 +12,35 @@
   "Git_module1": {
     "prefix": "Git Module by ref",
     "body": [
-      "mod '${1:name}',",
-      "\t:git => '${2:repository}',",
-      "\t:ref => '${3:reference}'"
+      "mod '${1:name}', :git => '${2:repository}', :ref => '${3:reference}'"
     ],
     "description": "Install from a git repository specified by a git reference e.g. master"
   },
   "Git_module2": {
     "prefix": "Git Module by commit",
     "body": [
-      "mod '${1:name}',",
-      "\t:git    => '${2:repository}',",
-      "\t:commit => '${3:commit}'"
+      "mod '${1:name}', :git => '${2:repository}', :commit => '${3:commit}'"
     ],
     "description": "Install from a git repository specified by a git commit e.g. 1c40e29"
   },
   "Git_module3": {
     "prefix": "Git Module by tag",
     "body": [
-      "mod '${1:name}',",
-      "\t:git => '${2:repository}',",
-      "\t:tag => '${3:tag}'"
+      "mod '${1:name}', :git => '${2:repository}', :tag => '${3:tag}'"
     ],
     "description": "Install from a git repository specified by a git tag e.g. v1.0.0"
   },
   "Git_module4": {
     "prefix": "Git Module by branch",
     "body": [
-      "mod '${1:name}',",
-      "\t:git    => '${2:repository}',",
-      "\t:branch => '${3:branch}'"
+      "mod '${1:name}', :git => '${2:repository}', :branch => '${3:branch}'"
     ],
     "description": "Install from a git repository specified by a git branch e.g. release"
   },
   "Svn_module1": {
     "prefix": "Svn Module by revision",
     "body": [
-      "mod '${1:name}',",
-      "\t:svn      => '${2:repository}',",
-      "\t:revision => '${3:revision}'"
+      "mod '${1:name}', :svn => '${2:repository}', :revision => '${3:revision}'"
     ],
     "description": "Install from a SVN repository specified by a revision e.g. 154"
   },


### PR DESCRIPTION
Previously the snippets for adding modules into the Puppetfile broke
over multiple lines.  However the more "normal" way is to always
have them on a single line.

This commit converts the snippets to use a single line.