### PR TITLE
(maint) Update Editor-Syntax to 1.3.1

### DIFF
--- a/editor-components.json
+++ b/editor-components.json
@@ -3,6 +3,6 @@
     "release": "0.19.0"
   },
   "editor-syntax": {
-    "release": "1.3.0"
+    "release": "1.3.1"
   }
 }


### PR DESCRIPTION
This commit updates editor-syntax to 1.3.1, which is a bugfix update.