### PR TITLE
(GH-502) change the default install type to PDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -396,7 +396,7 @@
         },
         "puppet.installType": {
           "type": "string",
-          "default": "agent",
+          "default": "pdk",
           "description": "The type of Puppet installation. Either the Puppet Development Kit (pdk) or the Puppet Agent (agent)",
           "enum": [
             "pdk",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -163,7 +163,7 @@ export function DefaultWorkspaceSettings(): ISettings {
       enable: true
     },
     installDirectory: undefined,
-    installType: PuppetInstallType.PUPPET,
+    installType: PuppetInstallType.PDK,
     lint: {
       enable: true,
     },

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -21,10 +21,10 @@ suite("Configuration Tests", () => {
       break;
   }
 
-  test("resolves puppetBaseDir as puppet with default installtype", () => {
+  test("resolves pdkPuppetBaseDir as puppet with default installtype", () => {
     const settings: ISettings = DefaultWorkspaceSettings();
     var config = CreateAggregrateConfiguration(settings);
-    assert.equal(config.ruby.puppetBaseDir, puppetBaseDir);
+    assert.equal(config.ruby.puppetBaseDir, pdkPuppetBaseDir);
   });
 
   test("resolves puppetBaseDir as puppet with installtype eq puppet", () => {


### PR DESCRIPTION
https://github.com/lingua-pupuli/puppet-vscode/issues/502

Change the PuppetInstallType default to PDK

This will reduce the number of steps to getting the plugin working now that PDK is available.

Could not do testing as detailed in the contrib guide as there are no spec tests.