### PR TITLE
(maint) Update recommended tslint extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
   "recommendations": [
     "eamodio.gitlens",
-    "eg2.tslint",
+    "ms-vscode.vscode-typescript-tslint-plugin",
     "wwm.better-align",
     "rebornix.Ruby"
   ]


### PR DESCRIPTION
This commit updates the recommended tslint extension to
`ms-vscode.vscode-typescript-tslint-plugin`. The `eg2.tslint` extension
is deprecated.