### PR TITLE
(GH-530) Enable Extension on Workspace files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+
+- ([GH-530](https://github.com/lingua-pupuli/puppet-vscode/issues/530)) Enable extension with Puppet workspace files
+
 ## [0.18.1] - 2019-06-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
   "activationEvents": [
     "onLanguage:puppet",
     "onLanguage:puppetfile",
+    "workspaceContains:**/*.pp",
+    "workspaceContains:**/*.epp",
+    "workspaceContains:**/Puppetfile",
     "onCommand:extension.puppetShowConnectionLogs",
     "onCommand:extension.puppetShowConnectionMenu",
     "onCommand:extension.puppetLint",


### PR DESCRIPTION
This PR adds a file watcher to the `activationEvents` that initializes the extension if there are any Puppet or metadata.json files