### PR TITLE
(GH-534) Puppet Module Metadata hover provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3552,6 +3552,11 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.1.0.tgz",
+      "integrity": "sha512-n9GrT8rrr2fhvBbANa1g+xFmgGK5X91KFeDwlKQ3+SJfmH5+tKv/M/kahx/TXOMflfWHKGKqKyfHQaLKTNzJ6w=="
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -332,6 +332,11 @@
           "default": [],
           "description": "An array of strings of experimental features to enable in the Puppet Editor Service"
         },
+        "puppet.editorService.hover.showMetadataInfo": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable or disable showing Puppet Module version information in the metadata.json file"
+        },
         "puppet.editorService.loglevel": {
           "type": "string",
           "default": "normal",
@@ -563,6 +568,7 @@
     "yargs": "^13.2.4"
   },
   "dependencies": {
+    "jsonc-parser": "~2.1.0",
     "viz.js": "~1.7.0",
     "vscode-debugadapter": "^1.19.0",
     "vscode-debugprotocol": "^1.19.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import { ILogger } from './logging';
 import { OutputChannelLogger } from './logging/outputchannel';
 import { legacySettings, SettingsFromWorkspace } from './settings';
 import { Reporter, reporter } from './telemetry/telemetry';
+import { PuppetModuleHoverFeature } from './feature/PuppetModuleHoverFeature';
 
 const axios = require('axios');
 
@@ -103,6 +104,10 @@ export function activate(context: vscode.ExtensionContext) {
   extensionFeatures.push(new NodeGraphFeature(puppetLangID, connectionHandler, logger, extContext));
   extensionFeatures.push(new PuppetResourceFeature(extContext, connectionHandler, logger));
   extensionFeatures.push(new DebuggingFeature(debugType, configSettings, extContext, logger));
+  
+  if(settings.hover.showMetadataInfo){
+    extensionFeatures.push(new PuppetModuleHoverFeature(extContext, logger));
+  }
 }
 
 export function deactivate() {

--- a/src/feature/PuppetModuleHoverFeature.ts
+++ b/src/feature/PuppetModuleHoverFeature.ts
@@ -1,0 +1,91 @@
+import * as vscode from 'vscode';
+import { getLocation } from 'jsonc-parser';
+import { IFeature } from '../feature';
+import { ILogger } from '../logging';
+
+export class PuppetModuleHoverFeature implements IFeature {
+  constructor(public context: vscode.ExtensionContext, public logger: ILogger) {
+    let selector = [{ language: 'json', scheme: '*', pattern: '**/metadata.json' }];
+    context.subscriptions.push(vscode.languages.registerHoverProvider(selector, new PuppetModuleHoverProvider(logger)));
+  }
+
+  dispose() {}
+}
+
+export class PuppetModuleHoverProvider implements vscode.HoverProvider {
+  constructor(public logger: ILogger) {}
+
+  provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+  ): Thenable<vscode.Hover> | null {
+    const offset = document.offsetAt(position);
+    const location = getLocation(document.getText(), offset);
+
+    if (location.isAtPropertyKey) {
+      return;
+    }
+
+    if (location.path[0] !== 'dependencies') {
+      return;
+    }
+
+    if (location.path[2] !== 'name') {
+      return;
+    }
+
+    const range = document.getWordRangeAtPosition(position);
+    const word = document.getText(range);
+
+    this.logger.debug('Metadata hover info found ' + word + ' module');
+
+    let name = word
+      .replace('"', '')
+      .replace('"', '')
+      .replace('/', '-');
+
+    return this.getModuleInfo(name).then(function(result: any) {
+      let msg: string[] = [];
+      msg.push(`### ${result.slug}`);
+
+      const releaseDate = new Date(result.releases[0].created_at);
+      const dateformat = require('dateformat');
+      msg.push(`\nLatest version: ${result.releases[0].version} (${dateformat(releaseDate, 'dS mmmm yyyy')})`);
+
+      if (result.endorsement !== null) {
+        const endorsementCapitalized = result.endorsement.charAt(0).toUpperCase() + result.endorsement.slice(1);
+        msg.push(`\nEndorsement: ${endorsementCapitalized}`);
+      }
+
+      msg.push(`\nOwner: ${result.owner.slug}`);
+
+      const forgeUri = `https://forge.puppet.com/${result.owner.username}/${result.name}`;
+      msg.push(`\nForge: \[${forgeUri}\](${forgeUri})\n`);
+
+      if (result.homepage_url !== null) {
+        msg.push(`\nProject: \[${result.homepage_url}\](${result.homepage_url})\n`);
+      }
+
+      let md = msg.join('\n');
+
+      return Promise.resolve(new vscode.Hover(new vscode.MarkdownString(md), range));
+    });
+  }
+
+  private getModuleInfo(name: string) {
+    var options = {
+      url: `https://forgeapi.puppet.com/v3/modules/${name}?exclude_fields=readme%20changelog%20license%20reference`
+    };
+    return new Promise(function(resolve, reject) {
+      const request = require('request');
+      request.get(options, function(err, resp, body) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(JSON.parse(body));
+        }
+      });
+    });
+  }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -53,6 +53,10 @@ export interface IEditorServiceSettings {
 export interface IFormatSettings {
   enable?: boolean;
 }
+export interface IHoverSettings {
+  showMetadataInfo?: boolean;
+  // showPuppetfileInfo?: boolean; Future use
+}
 
 export interface ILintSettings {
   // Future Use
@@ -71,6 +75,7 @@ export interface INotificationSettings {
 export interface ISettings {
   editorService?: IEditorServiceSettings;
   format?: IFormatSettings;
+  hover?: IHoverSettings;
   installDirectory?: string;
   installType?: PuppetInstallType;
   lint?: ILintSettings;
@@ -163,6 +168,9 @@ export function DefaultWorkspaceSettings(): ISettings {
     format: {
       enable: true
     },
+    hover: {
+      showMetadataInfo: true,
+    },
     installDirectory: undefined,
     installType: PuppetInstallType.AUTO,
     lint: {
@@ -186,6 +194,7 @@ export function SettingsFromWorkspace(): ISettings {
   let settings = {
     editorService: workspaceConfig.get<IEditorServiceSettings>("editorService", defaults.editorService),
     format: workspaceConfig.get<IFormatSettings>("format",  defaults.format),
+    hover: workspaceConfig.get<IHoverSettings>("hover",  defaults.hover),
     installDirectory: workspaceConfig.get<string>("installDirectory",  defaults.installDirectory),
     installType: workspaceConfig.get<PuppetInstallType>("installType",  defaults.installType),
     lint: workspaceConfig.get<ILintSettings>("lint",  defaults.lint),


### PR DESCRIPTION
This PR introduces a new hover provider for Puppet Module metadata.json files. When a user hovers over a puppet module declared in the `dependencies` list, the provider queries the Puppet Forge api for latest version information, then displays this to the user.

Fixes #534