### PR TITLE
{WIP} align hashrocket experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,22 @@ To use a custom install path for the Puppet-Agent, set the `puppet.installDirect
 }
 ```
 
+#### Turning on experimental features
+
+To assist in trying out new features the Puppet extension can turn on feature flags, which by default are turned off. Features are enabled by configuring the `puppet.editorService.featureFlags` setting. The available feature flags are:
+
+##### `hashrocket`
+
+Turns on the [Format As You Type](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#incrementally-format-code-as-the-user-types) feature and auto aligns hash rockets after you type ` =>`
+
+Note - This feature requires `"editor.formatOnType": true` to be enabled
+
+``` json
+{
+  "puppet.editorService.featureFlags": ["hashrocket"]
+}
+```
+
 ## Experience a Problem?
 
 ### Puppet Agent Install

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { CreateAggregrateConfiguration, IAggregateConfiguration } from './configuration';
 import { IFeature } from './feature';
+import { AlignHashRocketsFeature } from './feature/AlignHashRocketsFeature';
 import { BoltFeature } from './feature/BoltFeature';
 import { DebuggingFeature } from './feature/DebuggingFeature';
 import { FormatDocumentFeature } from './feature/FormatDocumentFeature';
@@ -93,6 +94,7 @@ export function activate(context: vscode.ExtensionContext) {
   extensionFeatures.push(new NodeGraphFeature(puppetLangID, connectionHandler, logger, extContext));
   extensionFeatures.push(new PuppetResourceFeature(extContext, connectionHandler, logger));
   extensionFeatures.push(new DebuggingFeature(debugType, configSettings, extContext, logger));
+  extensionFeatures.push(new AlignHashRocketsFeature(puppetLangID, configSettings, extContext, logger));
 }
 
 export function deactivate() {

--- a/src/feature/AlignHashRocketsFeature.ts
+++ b/src/feature/AlignHashRocketsFeature.ts
@@ -1,0 +1,125 @@
+import { IFeature } from '../feature';
+import * as vscode from "vscode";
+import { ILogger } from "../logging";
+import { IAggregateConfiguration } from "../configuration";
+
+class HashRocketLocation {
+  public rocketIndex: number;
+  public preceedingTextIndex: number;
+}
+
+class AlignHashRocketsFormatter implements vscode.OnTypeFormattingEditProvider{
+  private logger: ILogger;
+
+  constructor(logger: ILogger) {
+    this.logger = logger;
+  }
+
+  private extractHashRocketLocation(document: vscode.TextDocument, line: number): HashRocketLocation {
+    if (line < 0 || line > document.lineCount) { return null; }
+
+    var textLine = document.lineAt(line);
+    // Find the first hash-rocket `=>`
+    var hashRocket = textLine.text.indexOf(' =>');
+    if (hashRocket === -1) { return null; }
+
+    // Now find where the preceeding text ends
+    var textIndex = textLine.text.substr(0, hashRocket).trimRight().length;
+    //        key    => value 
+    //           |  | <--- this is hashRocket
+    //           | <--- this is textIndex
+    var result: HashRocketLocation = {
+      rocketIndex: hashRocket + 1,
+      preceedingTextIndex: textIndex
+    };
+
+    return result;
+  }
+
+  public provideOnTypeFormattingEdits(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    ch: string,
+    options: vscode.FormattingOptions,
+    token: vscode.CancellationToken):
+    Thenable<vscode.TextEdit[]>
+  {
+    //TODO: Check options for tabs vs spaces
+
+    // Check if we're at the end of an expected hash rocket
+    if (document.getText(new vscode.Range(position.line, position.character - 3, position.line, position.character)) !== ' =>') {
+      return null;
+    }
+
+    var logger = this.logger;
+    var extractor = this.extractHashRocketLocation;
+
+    return new Promise<vscode.TextEdit[]>(function (resolve) {
+      var result: vscode.TextEdit[] = [];
+      var rocketLocations: Map<number, HashRocketLocation> = new Map<number, HashRocketLocation>();
+      // Get the hash rocket location for the current position
+      var location = extractor(document, position.line);
+      // If we couldn't find one, or it's different towhat we expect, pull the ripcord!
+      if (location === null) { return null; }
+      if (location.rocketIndex !== position.character - 2) { return null; } // -2 becuase we need to go back the two characters in the hash rocket
+      rocketLocations.set(position.line, location);
+
+      // Find the hash rocket lines after this one
+      var lineNum = position.line;
+      do {
+        lineNum--;
+        location = extractor(document, lineNum);
+        if (location !== null) { rocketLocations.set(lineNum, location); }
+      } while (location !== null);
+
+      // Find the hash rocket lines before this one
+      lineNum = position.line;
+      do {
+        lineNum++;
+        location = extractor(document, lineNum);
+        if (location !== null) { rocketLocations.set(lineNum, location); }
+      } while (location !== null);
+
+      // Find the largest preceeding text and then add 1, this is where the hash rocket _should_ be.
+      var correctIndex:number = -1;
+      rocketLocations.forEach( (value) => {
+        if (value.preceedingTextIndex > correctIndex) { correctIndex = value.preceedingTextIndex; }
+      });
+      correctIndex++;
+
+      // Construct required TextEdits
+      rocketLocations.forEach((value, key) => {
+        // Only create a TextEdit if the hash rocket is in the wrong location
+        if (value.rocketIndex !== correctIndex) {
+          var te = new vscode.TextEdit(
+            new vscode.Range(key, value.preceedingTextIndex, key, value.rocketIndex),
+            ' '.repeat(correctIndex - value.preceedingTextIndex)
+          );
+          logger.debug(`[${key}] = ` + JSON.stringify(value));
+          result.push(te);
+        }
+      });
+      resolve(result);
+    });
+  }
+}
+
+export class AlignHashRocketsFeature implements IFeature {
+  private provider: vscode.OnTypeFormattingEditProvider;
+
+  constructor(
+    langID: string,
+    config: IAggregateConfiguration,
+    context: vscode.ExtensionContext,
+    logger: ILogger
+  ) {
+    // Check if the hashrocket feature flah has been set
+    if (!config.workspace.editorService.featureFlags.includes('hashrocket')) { return; }
+    this.provider = new AlignHashRocketsFormatter(logger);
+    context.subscriptions.push(vscode.languages.registerOnTypeFormattingEditProvider(langID, this.provider, '>'));
+    logger.debug("Registered On Type Formatting Edit provider");
+
+  }
+
+  public dispose(): any { return undefined; }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,7 +42,7 @@ export interface IEditorServiceSettings {
   debugFilePath?: string;
   docker?: IEditorServiceDockerSettings;
   enable?: boolean;
-  featureflags?: string[];
+  featureFlags?: string[];
   loglevel?: string;
   protocol?: ProtocolType;
   puppet?: IEditorServicePuppetSettings;
@@ -155,7 +155,7 @@ export function DefaultWorkspaceSettings(): ISettings {
   return {
     editorService: {
       enable: true,
-      featureflags: [],
+      featureFlags: [],
       loglevel: "normal",
       protocol: ProtocolType.STDIO,
       timeout: 10
@@ -201,7 +201,7 @@ export function SettingsFromWorkspace(): ISettings {
 
    // Ensure that object types needed for legacy settings exists
   if (settings.editorService === undefined) { settings.editorService = {}; }
-  if (settings.editorService.featureflags === undefined) { settings.editorService.featureflags = []; }
+  if (settings.editorService.featureFlags === undefined) { settings.editorService.featureFlags = []; }
   if (settings.editorService.puppet === undefined) { settings.editorService.puppet = {}; }
   if (settings.editorService.tcp === undefined) { settings.editorService.tcp = {}; }
 
@@ -233,7 +233,7 @@ export function SettingsFromWorkspace(): ISettings {
         break;
 
       case "puppet.languageserver.filecache.enable": // --> puppet.editorService.featureflags['filecache']
-        if (value === true) { settings.editorService.featureflags.push("filecache"); }
+        if (value === true) { settings.editorService.featureFlags.push("filecache"); }
         break;
 
       case "puppet.languageserver.port": // --> puppet.editorService.tcp.port


### PR DESCRIPTION
The package.json lists the feature flag to be "featureFlag" with a capital F,
however the settings class expected a lowercase f.  This commit updates the
settings class to ues the expected capital F.  Without this change, no
feature flags can be set.

---

This commit adds an auto-aligner for the hash rocket (=>) for .pp files.  This
feature is hidden behind the 'hashrocket' featureflag as it may have unintended
consequences and reformat user's files unexpectedly.

The auto-align triggers on the `>` character.
* The provider then determines if the user is in a hashrocket.
* It then looks at the preceeding and proceeding lines to determine the block
  of hash rockets to consider
* Once it has block of lines, it determines the smallest hash rocket location
  and edits the text file appropriately.
