### PR TITLE
(maint) Fix typo for featureFlag

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,7 +42,7 @@ export interface IEditorServiceSettings {
   debugFilePath?: string;
   docker?: IEditorServiceDockerSettings;
   enable?: boolean;
-  featureflags?: string[];
+  featureFlags?: string[];
   loglevel?: string;
   protocol?: ProtocolType;
   puppet?: IEditorServicePuppetSettings;
@@ -155,7 +155,7 @@ export function DefaultWorkspaceSettings(): ISettings {
   return {
     editorService: {
       enable: true,
-      featureflags: [],
+      featureFlags: [],
       loglevel: "normal",
       protocol: ProtocolType.STDIO,
       timeout: 10
@@ -201,7 +201,7 @@ export function SettingsFromWorkspace(): ISettings {
 
    // Ensure that object types needed for legacy settings exists
   if (settings.editorService === undefined) { settings.editorService = {}; }
-  if (settings.editorService.featureflags === undefined) { settings.editorService.featureflags = []; }
+  if (settings.editorService.featureFlags === undefined) { settings.editorService.featureFlags = []; }
   if (settings.editorService.puppet === undefined) { settings.editorService.puppet = {}; }
   if (settings.editorService.tcp === undefined) { settings.editorService.tcp = {}; }
 
@@ -233,7 +233,7 @@ export function SettingsFromWorkspace(): ISettings {
         break;
 
       case "puppet.languageserver.filecache.enable": // --> puppet.editorService.featureflags['filecache']
-        if (value === true) { settings.editorService.featureflags.push("filecache"); }
+        if (value === true) { settings.editorService.featureFlags.push("filecache"); }
         break;
 
       case "puppet.languageserver.port": // --> puppet.editorService.tcp.port


### PR DESCRIPTION
The package.json lists the feature flag to be "featureFlag" with a capital F,
however the settings class expected a lowercase f.  This commit updates the
settings class to ues the expected capital F.  Without this change, no
feature flags can be set.
