### PR TITLE
(GH-546) Update Puppet DAG svg icon

### DIFF
--- a/images/puppet-dag-dark.svg
+++ b/images/puppet-dag-dark.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="32px" height="32px" viewBox="0 0 100 154" version="1.1"  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+      <g id="dep" transform="translate(4.000000, 6.000000)" fill="#ffffff">
+        <g id="Page-1">
+          <path
+            d="M15.191,138.231 L30.382,138.231 L30.382,123.039 L15.191,123.039 L15.191,138.231 Z M15.192,31.174 L30.382,31.174 L30.382,15.984 L15.192,15.984 L15.192,31.174 Z M99.124,99.894 L99.124,54.32 L64.27,54.32 L64.281,54.309 L45.574,35.602 L45.574,0.792 L0,0.792 L0,46.366 L34.854,46.366 L53.539,65.051 L53.55,65.04 L53.55,89.174 L53.528,89.152 L34.832,107.848 L0,107.848 L0,153.422 L45.574,153.422 L45.574,118.59 L64.27,99.894 L99.124,99.894 L99.124,99.894 Z" id="Shape"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/images/puppet-dag-light.svg
+++ b/images/puppet-dag-light.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="32px" height="32px" viewBox="0 0 100 154" version="1.1"  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+      <g id="dep" transform="translate(4.000000, 6.000000)" fill="#3c3a3a">
+        <g id="Page-1">
+          <path
+            d="M15.191,138.231 L30.382,138.231 L30.382,123.039 L15.191,123.039 L15.191,138.231 Z M15.192,31.174 L30.382,31.174 L30.382,15.984 L15.192,15.984 L15.192,31.174 Z M99.124,99.894 L99.124,54.32 L64.27,54.32 L64.281,54.309 L45.574,35.602 L45.574,0.792 L0,0.792 L0,46.366 L34.854,46.366 L53.539,65.051 L53.55,65.04 L53.55,89.174 L53.528,89.152 L34.832,107.848 L0,107.848 L0,153.422 L45.574,153.422 L45.574,118.59 L64.27,99.894 L99.124,99.894 L99.124,99.894 Z" id="Shape"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/package.json
+++ b/package.json
@@ -148,8 +148,8 @@
         "category": "Puppet",
         "title": "PDK New Module",
         "icon": {
-          "dark": "images/puppet_logo_sm.svg",
-          "light": "images/puppet_logo_sm.svg"
+          "dark": "images/puppet-dag-dark.svg",
+          "light": "images/puppet-dag-light.svg"
         }
       },
       {


### PR DESCRIPTION
This commit adds a dag svg that matches dark and light themes.

Fixes #546