### PR TITLE
(maint) Deprecate docker protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This extension provides full Puppet Language support for [Visual Studio Code](ht
 - Node graph preview
 - Puppet Development Kit integration
 - (Experimental) Local debugging of Puppet manifests
-- (Experimental) Docker Language Server support
+- **DEPRECATED** Docker Language Server support
 
 **It is currently in technical preview, so that we can gather bug reports and find out what new features to add.**
 
@@ -306,7 +306,7 @@ The [VSCode Debugging - Launch Configurations](https://code.visualstudio.com/doc
 
 ### Docker Language Server Support
 
-**Note - This is an experimental feature**
+**Note - This is feature is deprecated in favor of the Microsoft Remote Container Extension and will be removed in a future release**
 
 The Puppet VSCode extension bundles the Puppet Language Server inside the extension, and loads the language server on demaned and communicates it with either STDIO or TCP. Another option is to communicate via TCP pointed towards a docker container running the Puppet Language Server. The Lingua-Pupuli organization maintains a Puppet Language Server docker container here: https://github.com/lingua-pupuli/images. Using this docker image, we can run the Puppet Language Server without having Puppet Agent or the Puppet Development Kit installed locally, all that is needed is a working docker installation.
 

--- a/package.json
+++ b/package.json
@@ -325,7 +325,7 @@
         "puppet.editorService.docker.imageName": {
           "type": "string",
           "default": "linguapupuli/puppet-language-server:latest",
-          "description": "The name of the image with tag that contains the Puppet Language server. For example: linguapupuli/puppet-language-server:latest"
+          "description": "**DEPRECATED** The name of the image with tag that contains the Puppet Language server. For example: linguapupuli/puppet-language-server:latest"
         },
         "puppet.editorService.featureFlags": {
           "type": "array",
@@ -347,7 +347,7 @@
         "puppet.editorService.protocol": {
           "type": "string",
           "default": "stdio",
-          "description": "The protocol used to communicate with the Puppet Editor Service.  By default the local STDIO protocol is used",
+          "description": "The protocol used to communicate with the Puppet Editor Service. By default the local STDIO protocol is used. The docker protocol is **DEPRECATED** and will be removed in a future version",
           "enum": [
             "stdio",
             "tcp",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,6 +85,7 @@ export function activate(context: vscode.ExtensionContext) {
       connectionHandler = new TcpConnectionHandler(extContext, statusBar, logger, configSettings);
       break;
     case ProtocolType.DOCKER:
+      vscode.window.showWarningMessage('The Puppet VSCode Docker protocol is deprecated in favor of the Microsoft Remote Container Extension. It will be removed in a future release');
       connectionHandler = new DockerConnectionHandler(extContext, statusBar, logger, configSettings);
       break;
   }


### PR DESCRIPTION
This commit announces the deprecation of the 'docker protocol' support
shipped in this extension. This extension still supports the concept of
running in docker containers, but the Microsoft Remote Container
extension can do this much better.