### PR TITLE
(maint) Update troubleshooting link

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,8 +168,8 @@ function checkInstallDirectory(config: IAggregateConfiguration, logger: ILogger)
 
     showErrorMessage(
       message,
-      'Configuration Information',
-      'https://github.com/lingua-pupuli/puppet-vscode#configuration',
+      'Troubleshooting Information',
+      'https://puppet-vscode.github.io/docs/experience-a-problem',
       logger
     );
     return false;


### PR DESCRIPTION
This changes the message popup that happens when a PDK or Puppet Agent
install is not found to point to the documentation website for
troubleshooting information.