### PR TITLE
(WIP)(GH-552) Disallow Puppet version change with TCP Protocol

### DIFF
--- a/src/feature/PuppetStatusBarFeature.ts
+++ b/src/feature/PuppetStatusBarFeature.ts
@@ -6,6 +6,7 @@ import { ILogger } from "../logging";
 import { ConnectionStatus } from '../interfaces';
 import { PuppetCommandStrings } from '../messages';
 import { IAggregateConfiguration } from "../configuration";
+import { ProtocolType } from "../settings";
 
 class PuppetStatusBarProvider {
   private statusBarItem: vscode.StatusBarItem;
@@ -80,7 +81,11 @@ class PuppetStatusBarProvider {
         () => { vscode.commands.executeCommand(PuppetCommandStrings.PuppetShowConnectionLogsCommandId); }),
     );
 
-    if (this.config.ruby.pdkPuppetVersions !== undefined && this.config.ruby.pdkPuppetVersions.length > 0) {
+    if (
+      this.config.ruby.pdkPuppetVersions !== undefined &&
+      this.config.ruby.pdkPuppetVersions.length > 0 &&
+      this.config.connection.protocol != ProtocolType.TCP
+      ) {
       // Add a static menu item to use the latest version
       menuItems.push(
         new PuppetConnectionMenuItem(


### PR DESCRIPTION
This commit warns the user that you cannot change the Puppet version
loaded when using a remote TCP Language Server.

Fixes #552