### PR TITLE
(maint) Stale issue management

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: "Issue Management"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been marked stale because it has been open for more than 30 days with no activity. If this issue is still important to you, please comment to keep this issue open. If not, this will be closed in 5 days'
+        stale-issue-label: 'no-issue-activity'
+        exempt-issue-label: 'awaiting-approval'
+        days-before-stale: 30
+        days-before-close: 5


### PR DESCRIPTION
This uses a github-action to mark all issues older than 30 days without
activity as stale. It closes all messages not replied to within 5 days.