### PR TITLE
(GH-588) Add server telemetry pass through

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -56,6 +56,10 @@ export abstract class ConnectionHandler {
       .onReady()
       .then(
         () => {
+          this.languageClient.onTelemetry(event => {
+            const eventName = event.Name ? event.Name : 'PUPPET_LANGUAGESERVER_EVENT';
+            reporter.sendTelemetryEvent(eventName, event.Measurements, event.Properties);
+          });
           this.setConnectionStatus('Loading Puppet', ConnectionStatus.Starting);
           this.queryLanguageServerStatusWithProgress();
         },


### PR DESCRIPTION
This commit adds a listener for telemetry events from the
Language Server, and then sends them to the telemetry reporter.

Fixes #588