### PR TITLE
(GH-592) Add Puppetfile resolver in Puppet-Editor-Services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ tmp/
 // Ignore generated module output
 *.vsix
 .vscode-test
+
+// Ignore temporary vendoring files
+editor_services.zip

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.21.0",
   "editorComponents": {
     "editorServices": {
-      "release": "0.22.0"
+      "release": "0.23.0"
     },
     "editorSyntax": {
       "release": "1.3.4"
@@ -394,6 +394,11 @@
         "puppet.editorService.tcp.address": {
           "type": "string",
           "description": "The IP address or hostname of the remote Puppet Editor Service to connect to, for example 'computer.domain' or '192.168.0.1'. Only applicable when the editorService.protocol is set to tcp"
+        },
+        "puppet.validate.resolvePuppetfiles": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable using dependency resolution for Puppetfiles"
         },
         "puppet.editorService.tcp.port": {
           "type": "integer",


### PR DESCRIPTION
Fixes #592 

Blocked by release of Editor Services with https://github.com/lingua-pupuli/puppet-editor-services/pull/197

---

Now that Editor Services now has support for doing dependency resolution the
extension can now take advantage of that. This commit:

* Updates Editor Services with the new version
* Adds a new setting puppet.validate.resolvePuppetfiles, with a default of true
