### PR TITLE
(maint) Remove Language Configuration JSON entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,7 @@
         "extensions": [
           ".pp",
           ".epp"
-        ],
-        "configuration": "./languages/puppet-language-configuration.json"
+        ]
       },
       {
         "id": "puppetfile",
@@ -101,8 +100,7 @@
         ],
         "filenames": [
           "Puppetfile"
-        ],
-        "configuration": "./languages/puppetfile-language-configuration.json"
+        ]
       }
     ],
     "jsonValidation": [


### PR DESCRIPTION
This PR removes the lines pointing to the language configuration
files from package.json that were removed in fa2ef7c3637cab7fe15f2068fd0c2c21650171f8