### PR TITLE
(GH-605) Use correct setting name for module path

### DIFF
--- a/src/helpers/commandHelper.ts
+++ b/src/helpers/commandHelper.ts
@@ -157,7 +157,7 @@ export class CommandEnvironmentHelper {
     [
       { name: 'confdir', value: settings.workspace.editorService.puppet.confdir },
       { name: 'environment', value: settings.workspace.editorService.puppet.environment },
-      { name: 'modulePath', value: settings.workspace.editorService.puppet.modulePath },
+      { name: 'modulepath', value: settings.workspace.editorService.puppet.modulePath },
       { name: 'vardir', value: settings.workspace.editorService.puppet.vardir }
     ].forEach(function (item) {
       if (item.value !== undefined && item.value !== '') {


### PR DESCRIPTION
Fixes #605 

Previously when passing through a module path to the language server it would
use the puppet setting `modulePath` however this is not cased correctly. This
commit uses the correct `modulepath` puppet setting.
