### PR TITLE
(GH-610) Fix surroundingPairs

### DIFF
--- a/languages/puppet-language-configuration.json
+++ b/languages/puppet-language-configuration.json
@@ -1,0 +1,38 @@
+{
+  "comments": {
+    // symbol used for single line comment. Remove this entry if your language does not support line comments
+    "lineComment": "#",
+    // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+    "blockComment": ["/*","*/"]
+  },
+  // symbols used as brackets
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  // symbols that are auto closed when typing
+  "autoClosingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  // symbols that that can be used to surround a selection
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  // support for region folding
+  "folding": {
+    "offSide": true,
+    "markers": {
+      "start": "^\\s*#\\s*region\\b",
+      "end": "^\\s*#\\s*endregion\\b"
+    }
+  }
+}

--- a/languages/puppetfile-language-configuration.json
+++ b/languages/puppetfile-language-configuration.json
@@ -1,0 +1,38 @@
+{
+  "comments": {
+    // symbol used for single line comment. Remove this entry if your language does not support line comments
+    "lineComment": "#",
+    // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+    "blockComment": ["/*","*/"]
+  },
+  // symbols used as brackets
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  // symbols that are auto closed when typing
+  "autoClosingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  // symbols that that can be used to surround a selection
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  // support for region folding
+  "folding": {
+    "offSide": true,
+    "markers": {
+      "start": "^\\s*#\\s*region\\b",
+      "end": "^\\s*#\\s*endregion\\b"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
         "extensions": [
           ".pp",
           ".epp"
-        ]
+        ],
+        "configuration": "./languages/puppet-language-configuration.json"
       },
       {
         "id": "puppetfile",
@@ -100,7 +101,8 @@
         ],
         "filenames": [
           "Puppetfile"
-        ]
+        ],
+        "configuration": "./languages/puppetfile-language-configuration.json"
       }
     ],
     "jsonValidation": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,8 +36,6 @@ let extensionFeatures: IFeature[] = [];
 
 export function activate(context: vscode.ExtensionContext) {
   extContext = context;
-  
-  setLanguageConfiguration();
 
   notifyOnNewExtensionVersion(extContext);
 
@@ -292,40 +290,4 @@ async function notifyIfNewPDKVersion(context: vscode.ExtensionContext, settings:
     .catch(error => {
       logger.error(error);
     });
-}
-
-function setLanguageConfiguration() {
-  vscode.languages.setLanguageConfiguration(puppetLangID, {
-    onEnterRules: [
-      {
-        // foo{'bar':}
-        beforeText: /^.*{\s{0,}'.*':/,
-        afterText: /\s{0,}}$/,
-        action: {
-          indentAction: vscode.IndentAction.IndentOutdent
-        }
-      }
-    ],
-    brackets: [
-      ["{", "}"],
-      ["[", "]"],
-      ["(", ")"]
-    ],
-    comments: {
-      lineComment: "#",
-      blockComment: ["/*", "*/"]
-    }
-  });
-  vscode.languages.setLanguageConfiguration(puppetFileLangID, {
-    onEnterRules: [],
-    brackets: [
-      ["{", "}"],
-      ["[", "]"],
-      ["(", ")"]
-    ],
-    comments: {
-      lineComment: "#",
-      blockComment: ["/*", "*/"]
-    }
-  });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,8 @@ let extensionFeatures: IFeature[] = [];
 export function activate(context: vscode.ExtensionContext) {
   extContext = context;
 
+  setLanguageConfiguration();
+
   notifyOnNewExtensionVersion(extContext);
 
   checkForLegacySettings();
@@ -290,4 +292,40 @@ async function notifyIfNewPDKVersion(context: vscode.ExtensionContext, settings:
     .catch(error => {
       logger.error(error);
     });
+}
+
+function setLanguageConfiguration() {
+  vscode.languages.setLanguageConfiguration(puppetLangID, {
+    onEnterRules: [
+      {
+        // foo{'bar':}
+        beforeText: /^.*{\s{0,}'.*':/,
+        afterText: /\s{0,}}$/,
+        action: {
+          indentAction: vscode.IndentAction.IndentOutdent
+        }
+      }
+    ],
+    brackets: [
+      ["{", "}"],
+      ["[", "]"],
+      ["(", ")"]
+    ],
+    comments: {
+      lineComment: "#",
+      blockComment: ["/*", "*/"]
+    }
+  });
+  vscode.languages.setLanguageConfiguration(puppetFileLangID, {
+    onEnterRules: [],
+    brackets: [
+      ["{", "}"],
+      ["[", "]"],
+      ["(", ")"]
+    ],
+    comments: {
+      lineComment: "#",
+      blockComment: ["/*", "*/"]
+    }
+  });
 }


### PR DESCRIPTION
In #289 I fixed properly indenting parameters after a type declaration with a title. This introduced a regression when trying to surround a token with quotes or brackets, it would instead replace the text instead of surrounding it. This happened because `surroundingPairs` was not included in the new programmatic method used. This PR reverts the previous commits, keeping the language configuration json files, and then re-adds the programmatic method

Fxies #610