### PR TITLE
Fix nightly workflow failures: BUILD_VERSION context and Node.js compatibility

### DIFF
--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: 'setup node: 18 platform: ${{ runner.os }}'
+      - name: 'setup node: 20 platform: ${{ runner.os }}'
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: npm install
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [20]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: npm test
         env:
-          BUILD_VERSION: '0.99.${{ github.event.number }}'
+          BUILD_VERSION: 0.99.${{ github.run_number }}
           VSCODE_BUILD_VERBOSE: true
           DISPLAY: ':99.0'
         shell: pwsh
@@ -72,7 +72,7 @@ jobs:
       - name: vsce package
         if: runner.os == 'Linux'
         env:
-          BUILD_VERSION: '0.99.${{ github.event.number }}'
+          BUILD_VERSION: 0.99.${{ github.run_number }}
         shell: pwsh
         run: |
           invoke-psake -properties @{ packageVersion = $env:BUILD_VERSION } -tasklist bump

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: '18.x'
+  NODE_VERSION: '20'
 
 jobs:
   release:

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -16,7 +16,7 @@ jobs:
     name: "Release Prep"
     runs-on: "ubuntu-latest"
     env:
-      NODE_VERSION: "18"
+      NODE_VERSION: "20"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [20]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -9,7 +9,7 @@ on:
       - "main"
   workflow_dispatch:
 
-env: 
+env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
@@ -76,8 +76,8 @@ jobs:
           npm run test:coverage
 
       - name: Upload Coverage
-        if: | 
-          runner.os == 'Linux' && 
+        if: |
+          runner.os == 'Linux' &&
           env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4
         with:
@@ -85,7 +85,7 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true
-        
+
       - name: vsce package
         if: runner.os == 'Linux'
         env:


### PR DESCRIPTION
## Problems

The nightly CI workflow fails due to two separate but related issues:

- **Invalid npm version on scheduled runs** - `github.event.number` is undefined for cron triggers, causing `npm error Invalid version: 0.99.`

  Changed `BUILD_VERSION` from `'0.99.${{ github.event.number }}'` to `0.99.${{ github.run_number }}`.   `github.run_number` is available for all workflow trigger types (scheduled, manual, PR) providing consistent versioning: `0.99.{run_number}` across all triggers

- **Node.js/undici compatibility failure** - vsce packaging fails with `ReferenceError: File is not defined` due to undici v7.13.0 requiring Node.js 20.18.1+

  Initially updated **nightly.yml** `node-version: [18]` to `[20]` and PR checks **vscode-ci.yml**.  When these all passed, then I updated all the other workflows to node 20 too, e.g.,  **mend.yml**, **release_prep.yml**, and **release.yml**.