### PR TITLE
fix: add missing bullet point for Open Symbol by Name in README table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Puppet VSCode website [https://puppet-vscode.github.io/](https://puppet-vsco
   - [Outline View](https://puppet-vscode.github.io/docs/features/code-navigation/)
   - [Breadcrumbs](https://puppet-vscode.github.io/docs/features/code-navigation/)
   - [Go to Symbol](https://puppet-vscode.github.io/docs/features/code-navigation/)
-    [Open Symbol by Name](https://puppet-vscode.github.io/docs/features/code-navigation/)
+  - [Open Symbol by Name](https://puppet-vscode.github.io/docs/features/code-navigation/)
   - [Code Snippets](#code-snippets)
   - [Linting](https://puppet-vscode.github.io/docs/features/linting/)
   - [Live Workspace Intellisense](https://puppet-vscode.github.io/docs/features/intellisense)


### PR DESCRIPTION
## Summary
- Fixes a missing bullet point in the README table of contents for "Open Symbol by Name"

## Test plan
- [ ] No functional changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)