### PR TITLE
(maint) Fix typo in responseToVSCodeEdit method name

### DIFF
--- a/src/feature/PuppetResourceFeature.ts
+++ b/src/feature/PuppetResourceFeature.ts
@@ -79,7 +79,7 @@ export class PuppetResourceFeature implements IFeature {
               return this._connectionHandler.languageClient
                 .sendRequest(PuppetResourceRequest.type, requestParams)
                 .then((resourceResult) => {
-                  this.respsonseToVSCodeEdit(resourceResult, editor, doc);
+                  this.responseToVSCodeEdit(resourceResult, editor, doc);
                 });
             },
           );
@@ -87,14 +87,14 @@ export class PuppetResourceFeature implements IFeature {
           this._connectionHandler.languageClient
             .sendRequest(PuppetResourceRequest.type, requestParams)
             .then((resourceResult) => {
-              this.respsonseToVSCodeEdit(resourceResult, editor, doc);
+              this.responseToVSCodeEdit(resourceResult, editor, doc);
             });
         }
       }
     });
   }
 
-  private respsonseToVSCodeEdit(
+  private responseToVSCodeEdit(
     resourceResult: PuppetResourceResponse,
     editor: vscode.TextEditor,
     doc: vscode.TextDocument,


### PR DESCRIPTION
## Summary

- Renames misspelled method `respsonseToVSCodeEdit` → `responseToVSCodeEdit` in `PuppetResourceFeature.ts`
- Updates both call sites to use the corrected name

## Test plan

- [ ] Verify the Puppet Resource command still works as expected in the extension
- [ ] Confirm no remaining references to the old misspelled name (`respsonseToVSCodeEdit`)